### PR TITLE
Support concurrent connections.

### DIFF
--- a/common/src/main/java/com/msd/gin/halyard/common/HalyardTableUtils.java
+++ b/common/src/main/java/com/msd/gin/halyard/common/HalyardTableUtils.java
@@ -40,9 +40,9 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
-import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.regionserver.BloomType;
@@ -136,18 +136,56 @@ public final class HalyardTableUtils {
     }
 
     /**
-     * Helper method which locates or creates and returns the specified HTable used for triple/ quad storage. The table may be pre-split into regions (rather than HBase's default
-     * of starting with 1). For a discussion of pre-splits take a look at <a href="https://hortonworks.com/blog/apache-hbase-region-splitting-and-merging/">this article</a>
-     * @param config Hadoop Configuration of the cluster running HBase
-     * @param tableName String table name
-     * @param create boolean option to create the table if does not exist
-     * @param splitBits int number of bits used for calculation of HTable region pre-splits (applies for new tables only). Must be between 0 and 16. Higher values generate more
-     * splits.
-     * @throws IOException throws IOException in case of any HBase IO problems
-     * @return the org.apache.hadoop.hbase.client.HTable
-     */
-    public static HTable getTable(Configuration config, String tableName, boolean create, int splitBits) throws IOException {
-        return getTable(config, tableName, create, splitBits < 0 ? null : calculateSplits(splitBits));
+	 * Helper method which locates or creates and returns the specified Table used
+	 * for triple/ quad storage. The table may be pre-split into regions (rather
+	 * than HBase's default of starting with 1). For a discussion of pre-splits take
+	 * a look at <a href=
+	 * "https://hortonworks.com/blog/apache-hbase-region-splitting-and-merging/">this
+	 * article</a>
+	 * 
+	 * @param config
+	 *            Hadoop Configuration of the cluster running HBase
+	 * @param tableName
+	 *            String table name
+	 * @param create
+	 *            boolean option to create the table if does not exist
+	 * @param splitBits
+	 *            int number of bits used for calculation of Table region pre-splits
+	 *            (applies for new tables only). Must be between 0 and 16. Higher
+	 *            values generate more splits.
+	 * @throws IOException
+	 *             throws IOException in case of any HBase IO problems
+	 * @return the org.apache.hadoop.hbase.client.Table
+	 */
+	public static Table getTable(Configuration config, String tableName, boolean create, int splitBits)
+			throws IOException {
+		return getTable(getConnection(config), tableName, create, splitBits);
+	}
+
+	/**
+	 * Helper method which locates or creates and returns the specified Table used
+	 * for triple/ quad storage. The table may be pre-split into regions (rather
+	 * than HBase's default of starting with 1). For a discussion of pre-splits take
+	 * a look at <a href=
+	 * "https://hortonworks.com/blog/apache-hbase-region-splitting-and-merging/">this
+	 * article</a>
+	 * 
+	 * @param conn
+	 *            Connection to the cluster running HBase
+	 * @param tableName
+	 *            String table name
+	 * @param create
+	 *            boolean option to create the table if does not exist
+	 * @param splitBits
+	 *            int number of bits used for calculation of Table region pre-splits
+	 *            (applies for new tables only). Must be between 0 and 16. Higher
+	 *            values generate more splits.
+	 * @throws IOException
+	 *             throws IOException in case of any HBase IO problems
+	 * @return the org.apache.hadoop.hbase.client.Table
+	 */
+	public static Table getTable(Connection conn, String tableName, boolean create, int splitBits) throws IOException {
+		return getTable(conn, tableName, create, splitBits < 0 ? null : calculateSplits(splitBits));
     }
 
     /**
@@ -159,50 +197,64 @@ public final class HalyardTableUtils {
      * @return HTable
      * @throws IOException throws IOException in case of any HBase IO problems
      */
-    public static HTable getTable(Configuration config, String tableName, boolean create, byte[][] splits) throws IOException {
-        Configuration cfg = HBaseConfiguration.create(config);
-        cfg.setLong(HConstants.HBASE_CLIENT_SCANNER_TIMEOUT_PERIOD, 3600000l);
+	public static Table getTable(Configuration config, String tableName, boolean create, byte[][] splits)
+			throws IOException {
+		return getTable(getConnection(config), tableName, create, splits);
+	}
+
+	/**
+	 * Helper method which locates or creates and returns the specified Table used
+	 * for triple/ quad storage
+	 * 
+	 * @param conn
+	 *            Connection to the cluster running HBase
+	 * @param tableName
+	 *            String table name
+	 * @param create
+	 *            boolean option to create the table if does not exists
+	 * @param splits
+	 *            array of keys used to pre-split new table, may be null
+	 * @return Table
+	 * @throws IOException
+	 *             throws IOException in case of any HBase IO problems
+	 */
+	public static Table getTable(Connection conn, String tableName, boolean create, byte[][] splits)
+			throws IOException {
+		TableName htableName = TableName.valueOf(tableName);
         if (create) {
-            try (Connection con = ConnectionFactory.createConnection(config)) {
-                try (Admin admin = con.getAdmin()) {
-                	    //check if the table exists and if it doesn't, make it
-                    if (!admin.tableExists(TableName.valueOf(tableName))) {
-                        HTableDescriptor td = new HTableDescriptor(TableName.valueOf(tableName));
-                        td.addFamily(createColumnFamily());
-                        admin.createTable(td, splits);
-                    }
+			try (Admin admin = conn.getAdmin()) {
+				// check if the table exists and if it doesn't, make it
+				if (!admin.tableExists(htableName)) {
+					HTableDescriptor td = new HTableDescriptor(htableName);
+					td.addFamily(createColumnFamily());
+					admin.createTable(td, splits);
                 }
             }
         }
+		return conn.getTable(htableName);
+	}
 
-        //this is deprecated, the recommendation now is to use connection.getTable()
-        HTable table = new HTable(cfg, tableName);
-        table.setAutoFlushTo(false);
-        return table;
-    }
+	public static Connection getConnection(Configuration config) throws IOException {
+		Configuration cfg = HBaseConfiguration.create(config);
+		cfg.setLong(HConstants.HBASE_CLIENT_SCANNER_TIMEOUT_PERIOD, 3600000l);
+		return ConnectionFactory.createConnection(cfg);
+	}
 
-    /**
-     * Truncates HTable while preserving the region pre-splits
-     * @param table HTable to truncate
-     * @return new instance of the truncated HTable
-     * @throws IOException throws IOException in case of any HBase IO problems
-     */
-    public static HTable truncateTable(HTable table) throws IOException {
-        Configuration conf = table.getConfiguration();
-        byte[][] presplits = table.getRegionLocator().getStartKeys();
-        if (presplits.length > 0 && presplits[0].length == 0) {
-            presplits = Arrays.copyOfRange(presplits, 1, presplits.length);
-        }
-        HTableDescriptor desc = table.getTableDescriptor();
-        table.close();
-        try (Connection con = ConnectionFactory.createConnection(conf)) {
-            try (Admin admin = con.getAdmin()) {
-                admin.disableTable(desc.getTableName());
-                admin.deleteTable(desc.getTableName());
-                admin.createTable(desc, presplits);
-            }
-        }
-        return HalyardTableUtils.getTable(conf, desc.getTableName().getNameAsString(), false, 0);
+	/**
+	 * Truncates Table while preserving the region pre-splits
+	 * 
+	 * @param conn
+	 *            connection to cluster
+	 * @param table
+	 *            Table to truncate
+	 * @throws IOException
+	 *             throws IOException in case of any HBase IO problems
+	 */
+	public static void truncateTable(Connection conn, Table table) throws IOException {
+		try (Admin admin = conn.getAdmin()) {
+			admin.disableTable(table.getName());
+			admin.truncateTable(table.getName(), true);
+		}
     }
 
     /**
@@ -375,10 +427,14 @@ public final class HalyardTableUtils {
     }
 
     /**
-     * Parser method returning all Statements from a single HBase Scan Result
-     * @param res HBase Scan Result
-     * @return List of Statements
-     */
+	 * Parser method returning all Statements from a single HBase Scan Result
+	 * 
+	 * @param res
+	 *            HBase Scan Result
+	 * @param vf
+	 *            ValueFactory
+	 * @return List of Statements
+	 */
     public static List<Statement> parseStatements(Result res, ValueFactory vf) {
     	// multiple triples may have the same hash (i.e. row key)
         ArrayList<Statement> st = new ArrayList<>();
@@ -389,10 +445,14 @@ public final class HalyardTableUtils {
     }
 
     /**
-     * Parser method returning Statement from a single HBase Result Cell
-     * @param c HBase Result Cell
-     * @return Statements
-     */
+	 * Parser method returning Statement from a single HBase Result Cell
+	 * 
+	 * @param c
+	 *            HBase Result Cell
+	 * @param vf
+	 *            ValueFactory
+	 * @return Statements
+	 */
     public static Statement parseStatement(Cell c, ValueFactory vf) {
         ByteBuffer bb = ByteBuffer.wrap(c.getQualifierArray(), c.getQualifierOffset(), c.getQualifierLength());
         byte[] sb = new byte[bb.getInt()];

--- a/common/src/test/java/com/msd/gin/halyard/common/HalyardTableUtilsScanTest.java
+++ b/common/src/test/java/com/msd/gin/halyard/common/HalyardTableUtilsScanTest.java
@@ -16,25 +16,30 @@
  */
 package com.msd.gin.halyard.common;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+
 import org.apache.hadoop.hbase.KeyValue;
-import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Table;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.AfterClass;
-import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import static org.junit.Assert.*;
 
 /**
  *
@@ -140,7 +145,7 @@ public class HalyardTableUtilsScanTest {
            });
     }
 
-    private static HTable table;
+	private static Table table;
     private static Set<Statement> allStatements;
 
     @BeforeClass
@@ -152,12 +157,13 @@ public class HalyardTableUtilsScanTest {
         allStatements.add(vf.createStatement(vf.createIRI(SUBJ1), vf.createIRI(PRED1), vf.createLiteral(EXPL1), vf.createIRI(CTX1)));
         allStatements.add(vf.createStatement(vf.createIRI(SUBJ2), vf.createIRI(PRED2), vf.createLiteral(EXPL2), vf.createIRI(CTX2)));
         long timestamp = System.currentTimeMillis();
+		List<Put> puts = new ArrayList<>();
         for (Statement st : allStatements) {
             for (KeyValue kv : HalyardTableUtils.toKeyValues(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext(), false, timestamp)) {
-                    table.put(new Put(kv.getRowArray(), kv.getRowOffset(), kv.getRowLength(), kv.getTimestamp()).add(kv));
+				puts.add(new Put(kv.getRowArray(), kv.getRowOffset(), kv.getRowLength(), kv.getTimestamp()).add(kv));
             }
         }
-        table.flushCommits();
+		table.put(puts);
     }
 
     @AfterClass

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,25 @@
         </pluginManagement>
     </build>
     <profiles>
+    	<profile>
+    		<id>windows</id>
+    		<activation>
+    			<os>
+    				<family>windows</family>
+    			</os>
+    		</activation>
+		    <dependencyManagement>
+		    	<dependencies>
+		    		<dependency>
+		    			<groupId>jdk.tools</groupId>
+		    			<artifactId>jdk.tools</artifactId>
+		    			<version>1.8</version>
+		    			<systemPath>${JAVA_HOME}/lib/tools.jar</systemPath>
+		    			<scope>system</scope>
+		    		</dependency>
+		    	</dependencies>
+		    </dependencyManagement>
+    	</profile>
         <profile>
             <id>third-party-licenses</id>
             <activation>

--- a/sail/src/main/java/com/msd/gin/halyard/sail/HBaseSail.java
+++ b/sail/src/main/java/com/msd/gin/halyard/sail/HBaseSail.java
@@ -16,94 +16,37 @@
  */
 package com.msd.gin.halyard.sail;
 
-import com.msd.gin.halyard.common.HalyardTableUtils;
-import com.msd.gin.halyard.optimizers.HalyardEvaluationStatistics;
-import com.msd.gin.halyard.optimizers.HalyardFilterOptimizer;
-import com.msd.gin.halyard.optimizers.HalyardQueryJoinOptimizer;
-import com.msd.gin.halyard.strategy.HalyardEvaluationStrategy;
-import com.msd.gin.halyard.strategy.HalyardEvaluationStrategy.ServiceRoot;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.WeakHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Hex;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.KeyValue;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Table;
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
-import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
-import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
-import org.eclipse.rdf4j.common.iteration.TimeLimitIteration;
-import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Namespace;
-import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.SD;
-import org.eclipse.rdf4j.model.vocabulary.VOID;
-import org.eclipse.rdf4j.query.Binding;
-import org.eclipse.rdf4j.query.BindingSet;
-import org.eclipse.rdf4j.query.Dataset;
-import org.eclipse.rdf4j.query.IncompatibleOperationException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
-import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
-import org.eclipse.rdf4j.query.algebra.FunctionCall;
-import org.eclipse.rdf4j.query.algebra.QueryRoot;
-import org.eclipse.rdf4j.query.algebra.Service;
-import org.eclipse.rdf4j.query.algebra.TupleExpr;
-import org.eclipse.rdf4j.query.algebra.ValueConstant;
-import org.eclipse.rdf4j.query.algebra.Var;
-import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
-import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
-import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedService;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.BindingAssigner;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.CompareOptimizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.ConjunctiveConstraintSplitter;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.ConstantOptimizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.DisjunctiveConstraintOptimizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.IterativeEvaluationOptimizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.OrderLimitOptimizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryModelNormalizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.SameTermFilterOptimizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
-import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
-import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
-import org.eclipse.rdf4j.repository.sparql.query.InsertBindingSetCursor;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import org.eclipse.rdf4j.sail.UnknownSailTransactionStateException;
-import org.eclipse.rdf4j.sail.UpdateContext;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONTokener;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.msd.gin.halyard.common.HalyardTableUtils;
+import com.msd.gin.halyard.optimizers.HalyardEvaluationStatistics;
 
 /**
  * HBaseSail is the RDF Storage And Inference Layer (SAIL) implementation on top of Apache HBase.
@@ -111,7 +54,7 @@ import org.json.JSONTokener;
  * only supported for queries across multiple graphs in one Halyard database.
  * @author Adam Sotona (MSD)
  */
-public class HBaseSail implements Sail, SailConnection, FederatedServiceResolver, FederatedService {
+public class HBaseSail implements Sail, FederatedServiceResolver {
 
     /**
      * Ticker is a simple service interface that is notified when some data are processed.
@@ -125,52 +68,87 @@ public class HBaseSail implements Sail, SailConnection, FederatedServiceResolver
         public void tick();
     }
 
-    private static final Logger LOG = Logger.getLogger(HBaseSail.class.getName());
+	/**
+	 * Interface to make it easy to change connection implementations.
+	 */
+	public interface ConnectionFactory {
+		SailConnection createConnection(HBaseSail sail);
+	}
+
     private static final long STATUS_CACHING_TIMEOUT = 60000l;
-    private static final int ELASTIC_RESULT_SIZE = 10000;
 
     private final Configuration config; //the configuration of the HBase database
     final String tableName;
     final boolean create;
     final boolean pushStrategy;
     final int splitBits;
-    protected final HalyardEvaluationStatistics statistics;
+	protected HalyardEvaluationStatistics statistics;
     final int evaluationTimeout;
     private boolean readOnly = false;
     private long readOnlyTimestamp = -1;
     final String elasticIndexURL;
-    private final Ticker ticker;
+    final Ticker ticker;
+	final ConnectionFactory connFactory;
+	Connection hConnection;
+	final boolean hConnectionIsShared; //whether a Connection is provided or we need to create our own
 
-    HTable table = null;
+    final Map<String, Namespace> namespaces = new ConcurrentHashMap<>();
+	private final Cache<String, SailFederatedService> federatedServices = CacheBuilder.newBuilder().maximumSize(100)
+			.removalListener((evt) -> ((SailFederatedService) evt.getValue()).shutdown()).build();
 
-    private final Map<String, Namespace> namespaces = new HashMap<>();
-    private final Map<String, HBaseSail> federatedServices = new HashMap<>();
 
-    /**
-     * Construct HBaseSail object with given arguments.
-     * @param config Hadoop Configuration to access HBase
-     * @param tableName HBase table name used to store data
-     * @param create boolean option to create the table if it does not exist
-     * @param splitBits int number of bits used for the calculation of HTable region pre-splits (applies for new tables only)
-     * @param pushStrategy boolean option to use {@link com.msd.gin.halyard.strategy.HalyardEvaluationStrategy} instead of {@link org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy}
-     * @param evaluationTimeout int timeout in seconds for each query evaluation, negative values mean no timeout
-     * @param elasticIndexURL String optional ElasticSearch index URL
-     * @param ticker optional Ticker callback for keep-alive notifications
-     */
-    public HBaseSail(Configuration config, String tableName, boolean create, int splitBits, boolean pushStrategy, int evaluationTimeout, String elasticIndexURL, Ticker ticker) {
+    private HBaseSail(Connection conn, Configuration config, String tableName, boolean create, int splitBits, boolean pushStrategy, int evaluationTimeout, String elasticIndexURL, Ticker ticker, ConnectionFactory connFactory) {
+    	this.hConnection = conn;
+    	this.hConnectionIsShared = (conn != null);
         this.config = config;
         this.tableName = tableName;
         this.create = create;
         this.splitBits = splitBits;
         this.pushStrategy = pushStrategy;
-        this.statistics = new HalyardEvaluationStatistics(new HalyardStatsBasedStatementPatternCardinalityCalculator(this), (String service) -> {
-            FederatedService servSail = getService(service);
-            return servSail != null ? ((HBaseSail)servSail).statistics : null;
-        });
         this.evaluationTimeout = evaluationTimeout;
         this.elasticIndexURL = elasticIndexURL;
         this.ticker = ticker;
+		this.connFactory = connFactory;
     }
+
+    /**
+	 * Construct HBaseSail object with given arguments.
+	 * 
+	 * @param config
+	 *            Hadoop Configuration to access HBase
+	 * @param tableName
+	 *            HBase table name used to store data
+	 * @param create
+	 *            boolean option to create the table if it does not exist
+	 * @param splitBits
+	 *            int number of bits used for the calculation of HTable region
+	 *            pre-splits (applies for new tables only)
+	 * @param pushStrategy
+	 *            boolean option to use
+	 *            {@link com.msd.gin.halyard.strategy.HalyardEvaluationStrategy}
+	 *            instead of
+	 *            {@link org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy}
+	 * @param evaluationTimeout
+	 *            int timeout in seconds for each query evaluation, negative values
+	 *            mean no timeout
+	 * @param elasticIndexURL
+	 *            String optional ElasticSearch index URL
+	 * @param ticker
+	 *            optional Ticker callback for keep-alive notifications
+	 * @param connFactory
+	 *            {@link ConnectionFactory} for creating connections
+	 */
+    public HBaseSail(Configuration config, String tableName, boolean create, int splitBits, boolean pushStrategy, int evaluationTimeout, String elasticIndexURL, Ticker ticker, ConnectionFactory connFactory) {
+    	this(null, config, tableName, create, splitBits, pushStrategy, evaluationTimeout, elasticIndexURL, ticker, connFactory);
+    }
+
+    public HBaseSail(Connection conn, String tableName, boolean create, int splitBits, boolean pushStrategy, int evaluationTimeout, String elasticIndexURL, Ticker ticker) {
+		this(conn, conn.getConfiguration(), tableName, create, splitBits, pushStrategy, evaluationTimeout, elasticIndexURL, ticker, HBaseSailConnection.Factory.INSTANCE);
+	}
+
+    public HBaseSail(Configuration config, String tableName, boolean create, int splitBits, boolean pushStrategy, int evaluationTimeout, String elasticIndexURL, Ticker ticker) {
+		this(null, config, tableName, create, splitBits, pushStrategy, evaluationTimeout, elasticIndexURL, ticker, HBaseSailConnection.Factory.INSTANCE);
+	}
 
     /**
      * Not used in Halyard
@@ -187,14 +165,42 @@ public class HBaseSail implements Sail, SailConnection, FederatedServiceResolver
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public void initialize() throws SailException { //initialize the SAIL
+    /**
+     * Returns a new HTable connection.
+     */
+	Table getTable() {
         try {
-        	    //get or create and get the HBase table
-            table = HalyardTableUtils.getTable(config, tableName, create, splitBits);
+			return HalyardTableUtils.getTable(hConnection, tableName, create, splitBits);
+		} catch (IOException e) {
+			throw new SailException(e);
+		}
+    }
 
+	BufferedMutator getBufferedMutator(Table table) {
+		try {
+			return hConnection.getBufferedMutator(table.getName());
+		} catch (IOException e) {
+			throw new SailException(e);
+		}
+	}
+
+	@Override
+    public void initialize() throws SailException { //initialize the SAIL
+    	if (!hConnectionIsShared) {
+			// connections are thread-safe and very heavyweight - only do it once
+        	if (hConnection != null) {
+        		throw new IllegalStateException("Sail has already been initialized");
+        	}
+			try {
+				hConnection = HalyardTableUtils.getConnection(config);
+			} catch (IOException e) {
+				throw new SailException(e);
+			}
+    	}
+
+    	try (SailConnection conn = getConnection()) {
             //Iterate over statements relating to namespaces and add them to the namespace map.
-            try (CloseableIteration<? extends Statement, SailException> nsIter = getStatements(null, HALYARD.NAMESPACE_PREFIX_PROPERTY, null, true)) {
+            try (CloseableIteration<? extends Statement, SailException> nsIter = conn.getStatements(null, HALYARD.NAMESPACE_PREFIX_PROPERTY, null, true)) {
                 while (nsIter.hasNext()) {
                     Statement st = nsIter.next();
                     if (st.getObject() instanceof Literal) {
@@ -204,83 +210,73 @@ public class HBaseSail implements Sail, SailConnection, FederatedServiceResolver
                     }
                 }
             }
-        } catch (IOException ex) {
-            throw new SailException(ex);
         }
+
+		this.statistics = new HalyardEvaluationStatistics(new HalyardStatsBasedStatementPatternCardinalityCalculator(this), (String service) -> {
+			SailFederatedService fedServ = getService(service);
+			return fedServ != null ? ((HBaseSail) fedServ.getSail()).statistics : null;
+		});
     }
 
     @Override
-    public FederatedService getService(String serviceUrl) throws QueryEvaluationException {
+	public SailFederatedService getService(String serviceUrl) throws QueryEvaluationException {
         //provide a service to query over Halyard graphs. Remote service queries are not supported.
         if (serviceUrl.startsWith(HALYARD.NAMESPACE)) {
             String federatedTable = serviceUrl.substring(HALYARD.NAMESPACE.length());
-            HBaseSail sail = federatedServices.get(federatedTable);
-            if (sail == null) {
-                sail = new HBaseSail(config, federatedTable, false, 0, true, evaluationTimeout, null, ticker);
-                federatedServices.put(federatedTable, sail);
-                sail.initialize();
-            }
-            return sail;
+            SailFederatedService federatedService;
+            try {
+				federatedService = federatedServices.get(federatedTable, () -> {
+				    HBaseSail sail = new HBaseSail(hConnection, config, federatedTable, false, 0, true, evaluationTimeout, null, ticker, HBaseSailConnection.Factory.INSTANCE);
+				    sail.initialize();
+				    return new SailFederatedService(sail);
+				});
+			}
+			catch (ExecutionException e) {
+				if (e.getCause() instanceof RuntimeException) {
+					throw (RuntimeException) e.getCause();
+				} else {
+					throw new AssertionError(e.getClass());
+				}
+			}
+            return federatedService;
         } else {
             throw new QueryEvaluationException("Unsupported service URL: " + serviceUrl);
         }
     }
 
     @Override
-    public boolean ask(Service service, BindingSet bindings, String baseUri) throws QueryEvaluationException {
-        try (CloseableIteration<BindingSet, QueryEvaluationException> res = evaluate(new ServiceRoot(service.getArg()), null, bindings, true)) {
-            return res.hasNext();
-        }
-    }
-
-    @Override
-    public CloseableIteration<BindingSet, QueryEvaluationException> select(Service service, Set<String> projectionVars, BindingSet bindings, String baseUri) throws QueryEvaluationException {
-        return new InsertBindingSetCursor(evaluate(new ServiceRoot(service.getArg()), null, bindings, true), bindings);
-    }
-
-    @Override
-    public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(Service service, CloseableIteration<BindingSet, QueryEvaluationException> bindings, String baseUri) throws QueryEvaluationException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean isInitialized() {
-        return table != null;
-    }
-
-    @Override
-    public void shutdown() throws QueryEvaluationException {
-        shutDown();
-    }
-
-    @Override
     public void shutDown() throws SailException { //release resources
-        try {
-            table.close(); //close the HTable
-            table = null;
-        } catch (IOException ex) {
-            throw new SailException(ex);
-        }
-        for (HBaseSail s : federatedServices.values()) { //shutdown all federated services
-            s.shutdown();
-        }
-        federatedServices.clear(); // release the references to the services
+		if (!hConnectionIsShared && hConnection != null) {
+			try {
+				hConnection.close();
+				hConnection = null;
+			} catch (IOException e) {
+				throw new SailException(e);
+			}
+		}
+
+		federatedServices.invalidateAll(); // release the references to the services
     }
 
     @Override
     public boolean isWritable() throws SailException {
-        if (readOnlyTimestamp + STATUS_CACHING_TIMEOUT < System.currentTimeMillis()) try {
-            readOnly = table.getTableDescriptor().isReadOnly();
-            readOnlyTimestamp = System.currentTimeMillis();
-        } catch (IOException ex) {
-            throw new SailException(ex);
-        }
+        if (readOnlyTimestamp + STATUS_CACHING_TIMEOUT < System.currentTimeMillis()) {
+			try (Table table = getTable()) {
+        		readOnly = table.getTableDescriptor().isReadOnly();
+	            readOnlyTimestamp = System.currentTimeMillis();
+	        } catch (IOException ex) {
+	            throw new SailException(ex);
+	        }
+	    }
         return !readOnly;
     }
 
     @Override
-    public SailConnection getConnection() throws SailException {
-        return this;
+	public SailConnection getConnection() throws SailException {
+		if (hConnection == null) {
+			throw new IllegalStateException("Sail is not initialized or has been shut down");
+		}
+		return connFactory.createConnection(this);
     }
 
     @Override
@@ -296,562 +292,5 @@ public class HBaseSail implements Sail, SailConnection, FederatedServiceResolver
     @Override
     public IsolationLevel getDefaultIsolationLevel() {
         return IsolationLevels.NONE;
-    }
-
-    @Override
-    public boolean isOpen() throws SailException {
-        return table != null;  //if the table exists the table is open
-    }
-
-    @Override
-    public void close() throws SailException {
-    }
-
-    //generates a Resource[] from 0 or more Resources
-    protected static Resource[] normalizeContexts(Resource... contexts) {
-        if (contexts == null || contexts.length == 0) {
-            return new Resource[] {null};
-        } else {
-            return contexts;
-        }
-    }
-
-    //evaluate queries/ subqueries
-    @Override
-    public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings, final boolean includeInferred) throws SailException {
-        LOG.log(Level.FINE, "Evaluated TupleExpr before optimizers:\n{0}", tupleExpr);
-        tupleExpr = tupleExpr.clone();
-        if (!(tupleExpr instanceof QueryRoot)) {
-            // Add a dummy root node to the tuple expressions to allow the
-            // optimizers to modify the actual root node
-            tupleExpr = new QueryRoot(tupleExpr);
-        }
-
-        final long startTime = System.currentTimeMillis();
-
-        TripleSource source = new TripleSource() {
-            @Override
-            public CloseableIteration<? extends Statement, QueryEvaluationException> getStatements(Resource subj, IRI pred, Value obj, Resource... contexts) throws QueryEvaluationException {
-                try {
-                    return new ExceptionConvertingIteration<Statement, QueryEvaluationException>(createScanner(startTime, subj, pred, obj, contexts)) {
-                        @Override
-                        protected QueryEvaluationException convert(Exception e) {
-                            return new QueryEvaluationException(e);
-                        }
-
-                    };
-                } catch (SailException ex) {
-                    throw new QueryEvaluationException(ex);
-                }
-            }
-
-            @Override
-            public ValueFactory getValueFactory() {
-                return HBaseSail.this.getValueFactory();
-            }
-        };
-
-        EvaluationStrategy strategy = pushStrategy ? new HalyardEvaluationStrategy(source, dataset, this, evaluationTimeout) : new StrictEvaluationStrategy(source, dataset, this);
-
-        new BindingAssigner().optimize(tupleExpr, dataset, bindings);
-        new ConstantOptimizer(strategy).optimize(tupleExpr, dataset, bindings);
-        new CompareOptimizer().optimize(tupleExpr, dataset, bindings);
-        new ConjunctiveConstraintSplitter().optimize(tupleExpr, dataset, bindings);
-        new DisjunctiveConstraintOptimizer().optimize(tupleExpr, dataset, bindings);
-        new SameTermFilterOptimizer().optimize(tupleExpr, dataset, bindings);
-        new QueryModelNormalizer().optimize(tupleExpr, dataset, bindings);
-        try {
-            //seach for presence of HALYARD.SEARCH_TYPE or HALYARD.PARALLEL_SPLIT_FUNCTION within the query
-            tupleExpr.visit(new AbstractQueryModelVisitor<IncompatibleOperationException>(){
-                private void checkForSearchType(Value val) {
-                    if (HALYARD.SEARCH_TYPE.equals(val) ||((val instanceof Literal) && HALYARD.SEARCH_TYPE.equals(((Literal)val).getDatatype()))) {
-                        throw new IncompatibleOperationException();
-                    }
-                }
-                @Override
-                public void meet(ValueConstant node) throws RuntimeException {
-                    checkForSearchType(node.getValue());
-                    super.meet(node);
-                }
-                @Override
-                public void meet(Var node) throws RuntimeException {
-                    if (node.hasValue()) {
-                        checkForSearchType(node.getValue());
-                    }
-                    super.meet(node);
-                }
-                @Override
-                public void meet(FunctionCall node) throws IncompatibleOperationException {
-                    if (HALYARD.PARALLEL_SPLIT_FUNCTION.toString().equals(node.getURI())) {
-                        throw new IncompatibleOperationException();
-                    }
-                    super.meet(node);
-                }
-                @Override
-                public void meet(BindingSetAssignment node) throws RuntimeException {
-                    for (BindingSet bs : node.getBindingSets()) {
-                        for (Binding b : bs) {
-                            checkForSearchType(b.getValue());
-                        }
-                    }
-                    super.meet(node);
-                }
-            });
-            new HalyardQueryJoinOptimizer(statistics).optimize(tupleExpr, dataset, bindings);
-        } catch (IncompatibleOperationException ioe) {
-            //skip HalyardQueryJoinOptimizer when  HALYARD.PARALLEL_SPLIT_FUNCTION or HALYARD.SEARCH_TYPE is present
-        }
-        // new SubSelectJoinOptimizer().optimize(tupleExpr, dataset, bindings);
-        new IterativeEvaluationOptimizer().optimize(tupleExpr, dataset, bindings);
-        new HalyardFilterOptimizer().optimize(tupleExpr, dataset, bindings); //apply filter optimizer twice (before and after Joins and Unions shaking)
-        new OrderLimitOptimizer().optimize(tupleExpr, dataset, bindings);
-        LOG.log(Level.FINE, "Evaluated TupleExpr after optimization:\n{0}", tupleExpr);
-        try {
-        		//evaluate the expression against the TripleSource according to the EvaluationStrategy.
-            CloseableIteration<BindingSet, QueryEvaluationException> iter = evaluateInternal(strategy, tupleExpr);
-            return evaluationTimeout <= 0 ? iter : new TimeLimitIteration<BindingSet, QueryEvaluationException>(iter, 1000l * evaluationTimeout) {
-                @Override
-                protected void throwInterruptedException() throws QueryEvaluationException {
-                    throw new QueryEvaluationException("Query evaluation exceeded specified timeout " + evaluationTimeout + "s");
-                }
-            };
-        } catch (QueryEvaluationException ex) {
-            throw new SailException(ex);
-        }
-    }
-
-    protected CloseableIteration<BindingSet, QueryEvaluationException> evaluateInternal(EvaluationStrategy strategy, TupleExpr tupleExpr) {
-        return strategy.evaluate(tupleExpr, EmptyBindingSet.getInstance());
-    }
-
-    @Override
-    public CloseableIteration<? extends Resource, SailException> getContextIDs() throws SailException {
-
-        //generate an iterator over the identifiers of the contexts available in Halyard.
-        final CloseableIteration<? extends Statement, SailException> scanner = getStatements(HALYARD.STATS_ROOT_NODE, SD.NAMED_GRAPH_PROPERTY, null, true, HALYARD.STATS_GRAPH_CONTEXT);
-        return new CloseableIteration<Resource, SailException>() {
-            @Override
-            public void close() throws SailException {
-                scanner.close();
-            }
-
-            @Override
-            public boolean hasNext() throws SailException {
-                return scanner.hasNext();
-            }
-
-            @Override
-            public Resource next() throws SailException {
-                return (IRI)scanner.next().getObject();
-            }
-
-            @Override
-            public void remove() throws SailException {
-                throw new UnsupportedOperationException();
-            }
-
-        };
-    }
-
-    @Override
-    public CloseableIteration<? extends Statement, SailException> getStatements(Resource subj, IRI pred, Value obj, boolean includeInferred, Resource... contexts) throws SailException {
-        return createScanner(System.currentTimeMillis(), subj, pred, obj, contexts);
-    }
-
-    private StatementScanner createScanner(long startTime, Resource subj, IRI pred, Value obj, Resource...contexts) throws SailException {
-        if ((obj instanceof Literal) && (HALYARD.SEARCH_TYPE.equals(((Literal)obj).getDatatype()))) {
-            return new LiteralSearchStatementScanner(startTime, subj, pred, obj.stringValue(), contexts);
-        } else {
-            return new StatementScanner(startTime, subj, pred, obj, contexts);
-        }
-    }
-
-    @Override
-    public synchronized long size(Resource... contexts) throws SailException {
-        long size = 0;
-        if (contexts != null && contexts.length > 0 && contexts[0] != null) {
-            for (Resource ctx : contexts) {
-            		//examine the VOID statistics for the count of triples in this context
-                try (CloseableIteration<? extends Statement, SailException> scanner = getStatements(ctx, VOID.TRIPLES, null, true, HALYARD.STATS_GRAPH_CONTEXT)) {
-                    if (scanner.hasNext()) {
-                        size += ((Literal)scanner.next().getObject()).longValue();
-                    }
-                    if (scanner.hasNext()) {
-                        throw new SailException("Multiple different values exist in VOID statistics for context: "+ctx.stringValue()+". Considering removing and recomputing statistics");
-                    }
-                }
-            }
-        } else {
-            try (CloseableIteration<? extends Statement, SailException> scanner = getStatements(HALYARD.STATS_ROOT_NODE, VOID.TRIPLES, null, true, HALYARD.STATS_GRAPH_CONTEXT)) {
-                if (scanner.hasNext()) {
-                    size += ((Literal)scanner.next().getObject()).longValue();
-                }
-                if (scanner.hasNext()) {
-                    throw new SailException("Multiple different values exist in VOID statistics. Considering removing and recomputing statistics");
-                }
-            }
-        }
-        // try to count it manually if there are no stats and there is a specific timeout
-        if (size == 0 && evaluationTimeout > 0) try (CloseableIteration<? extends Statement, SailException> scanner = getStatements(null, null, null, true, contexts)) {
-            while (scanner.hasNext()) {
-                scanner.next();
-                size++;
-            }
-        }
-        return size;
-    }
-
-    @Override
-    public void begin() throws SailException { //transactions are not supported
-    }
-
-    @Override
-    public void begin(IsolationLevel level) throws UnknownSailTransactionStateException, SailException {
-        if (level != null && level != IsolationLevels.NONE) {
-            throw new UnknownSailTransactionStateException("Isolation level " + level + " is not compatible with this HBaseSail");
-        }
-    }
-
-    @Override
-    public void flush() throws SailException {
-    }
-
-    @Override
-    public void prepare() throws SailException {
-    }
-
-    @Override
-    public void commit() throws SailException {
-        try {
-            table.flushCommits(); //execute all buffered puts in HBase
-        } catch (IOException ex) {
-            throw new SailException(ex);
-        }
-    }
-
-    @Override
-    public void rollback() throws SailException {
-    }
-
-    @Override
-    public boolean isActive() throws UnknownSailTransactionStateException {
-        return true;
-    }
-
-    @Override
-    public void addStatement(UpdateContext op, Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
-        addStatement(subj, pred, obj, contexts);
-    }
-
-    protected long getDefaultTimeStamp() {
-        return System.currentTimeMillis();
-    }
-
-    @Override
-    public void addStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
-        long timestamp = getDefaultTimeStamp();
-        for (Resource ctx : normalizeContexts(contexts)) {
-            addStatementInternal(subj, pred, obj, ctx, timestamp);
-        }
-    }
-
-    protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource context, long timestamp) throws SailException {
-        if (!isWritable()) throw new SailException(tableName + " is read only");
-        try {
-            for (KeyValue kv : HalyardTableUtils.toKeyValues(subj, pred, obj, context, false, timestamp)) { //serialize the key value pairs relating to the statement in HBase
-                put(kv);
-            }
-        } catch (IOException e) {
-            throw new SailException(e);
-        }
-    }
-
-    protected void put(KeyValue kv) throws IOException {
-        table.put(new Put(kv.getRowArray(), kv.getRowOffset(), kv.getRowLength(), kv.getTimestamp()).add(kv));
-    }
-
-    @Override
-    public void removeStatement(UpdateContext op, Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
-    	    //should we be defensive about nulls for subj, pre and obj? removeStatements is where you would use nulls, not here.
-
-        if (!isWritable()) throw new SailException(tableName + " is read only");
-        long timestamp = getDefaultTimeStamp();
-        try {
-            for (Resource ctx : normalizeContexts(contexts)) {
-                for (KeyValue kv : HalyardTableUtils.toKeyValues(subj, pred, obj, ctx, true, timestamp)) { //calculate the kv's corresponding to the quad (or triple)
-                    delete(kv);
-                }
-            }
-        } catch (IOException e) {
-            throw new SailException(e);
-        }
-    }
-
-    protected void delete(KeyValue kv) throws IOException {
-        table.delete(new Delete(kv.getRowArray(), kv.getRowOffset(), kv.getRowLength()).addDeleteMarker(kv));
-    }
-
-    @Override
-    public void removeStatements(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
-        if (!isWritable()) throw new SailException(tableName + " is read only");
-        contexts = normalizeContexts(contexts);
-        if (subj == null && pred == null && obj == null && contexts[0] == null) {
-            clearAll();
-        } else {
-            try (CloseableIteration<? extends Statement, SailException> iter = getStatements(subj, pred, obj, true, contexts)) {
-                while (iter.hasNext()) {
-                    Statement st = iter.next();
-                    removeStatement(null, st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
-                }
-            }
-        }
-    }
-
-    @Override
-    public boolean pendingRemovals() {
-        return false;
-    }
-
-    @Override
-    public void startUpdate(UpdateContext op) throws SailException {
-    }
-
-    @Override
-    public void endUpdate(UpdateContext op) throws SailException {
-    }
-
-    @Override
-    public void clear(Resource... contexts) throws SailException {
-        removeStatements(null, null, null, contexts); //remove all statements in the contexts.
-    }
-
-    private void clearAll() throws SailException {
-        if (!isWritable()) throw new SailException(tableName + " is read only");
-        try {
-            table = HalyardTableUtils.truncateTable(table); //delete all triples, the whole DB but retains splits!
-        } catch (IOException ex) {
-            throw new SailException(ex);
-        }
-    }
-
-    @Override
-    public String getNamespace(String prefix) throws SailException {
-        Namespace namespace = namespaces.get(prefix);
-        return (namespace == null) ? null : namespace.getName();
-    }
-
-    @Override
-    public CloseableIteration<? extends Namespace, SailException> getNamespaces() {
-        return new CloseableIteratorIteration<>(namespaces.values().iterator());
-    }
-
-    @Override
-    public void setNamespace(String prefix, String name) throws SailException {
-        namespaces.put(prefix, new SimpleNamespace(prefix, name));
-        ValueFactory vf = getValueFactory();
-        try {
-            removeStatements(null, HALYARD.NAMESPACE_PREFIX_PROPERTY, vf.createLiteral(prefix));
-            addStatementInternal(vf.createIRI(name), HALYARD.NAMESPACE_PREFIX_PROPERTY, vf.createLiteral(prefix), HALYARD.SYSTEM_GRAPH_CONTEXT, getDefaultTimeStamp());
-        } catch (SailException e) {
-            LOG.log(Level.WARNING, "Namespace prefix could not be presisted due to an exception", e);
-        }
-    }
-
-    @Override
-    public void removeNamespace(String prefix) throws SailException {
-        ValueFactory vf = getValueFactory();
-        namespaces.remove(prefix);
-        try {
-            removeStatements(null, HALYARD.NAMESPACE_PREFIX_PROPERTY, vf.createLiteral(prefix));
-        } catch (SailException e) {
-            LOG.log(Level.WARNING, "Namespace prefix could not be removed due to an exception", e);
-        }
-    }
-
-    @Override
-    public void clearNamespaces() throws SailException {
-        try {
-            removeStatements(null, HALYARD.NAMESPACE_PREFIX_PROPERTY, null);
-        } catch (SailException e) {
-            LOG.log(Level.WARNING, "Namespaces could not be cleared due to an exception", e);
-        }
-        namespaces.clear();
-    }
-
-    private static final Map <String, List<byte[]>> SEARCH_CACHE = new WeakHashMap<>();
-
-    //Scans the Halyard table for statements that match the specified pattern
-    private class LiteralSearchStatementScanner extends StatementScanner {
-
-        Iterator<byte[]> objectHashes = null;
-        private final String literalSearchQuery;
-
-        public LiteralSearchStatementScanner(long startTime, Resource subj, IRI pred, String literalSearchQuery, Resource... contexts) throws SailException {
-            super(startTime, subj, pred, null, contexts);
-            if (elasticIndexURL == null || elasticIndexURL.length() == 0) {
-                throw new SailException("ElasticSearch Index URL is not properly configured.");
-            }
-            this.literalSearchQuery = literalSearchQuery;
-        }
-
-        @Override
-        protected Result nextResult() throws IOException {
-            while (true) {
-                if (objHash == null) {
-                    if (objectHashes == null) { //perform ES query and parse results
-                        synchronized (SEARCH_CACHE) {
-                            List<byte[]> objectHashesList = SEARCH_CACHE.get(literalSearchQuery);
-                            if (objectHashesList == null) {
-                                objectHashesList = new ArrayList<>();
-                                HttpURLConnection http = (HttpURLConnection)(new URL(elasticIndexURL + "/_search").openConnection());
-                                try {
-                                    http.setRequestMethod("POST");
-                                    http.setDoOutput(true);
-                                    http.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
-                                    http.connect();
-                                    try (PrintStream out = new PrintStream(http.getOutputStream(), true, "UTF-8")) {
-                                        out.print("{\"query\":{\"query_string\":{\"query\":" + JSONObject.quote(literalSearchQuery) + "}},\"_source\":false,\"stored_fields\":\"_id\",\"size\":" + ELASTIC_RESULT_SIZE + "}");
-                                    }
-                                    int response = http.getResponseCode();
-                                    String msg = http.getResponseMessage();
-                                    if (response != 200) {
-                                        LOG.info("ElasticSearch error response: " + msg + " on query: " + literalSearchQuery);
-                                    } else {
-                                        try (InputStreamReader isr = new InputStreamReader(http.getInputStream(), "UTF-8")) {
-                                            JSONArray hits = new JSONObject(new JSONTokener(isr)).getJSONObject("hits").getJSONArray("hits");
-                                            for (int i=0; i<hits.length(); i++) {
-                                                objectHashesList.add(Hex.decodeHex(hits.getJSONObject(i).getString("_id").toCharArray()));
-                                            }
-                                        }
-                                        SEARCH_CACHE.put(new String(literalSearchQuery), objectHashesList);
-                                    }
-                                } catch (JSONException | DecoderException ex) {
-                                    throw new IOException(ex);
-                                } finally {
-                                    http.disconnect();
-                                }
-                            }
-                            objectHashes = objectHashesList.iterator();
-                        }
-                    }
-                    if (objectHashes.hasNext()) {
-                        objHash = objectHashes.next();
-                    } else {
-                        return null;
-                    }
-                    contexts = contextsList.iterator(); //reset iterator over contexts
-                }
-                Result res = super.nextResult();
-                if (res == null) {
-                    objHash = null;
-                } else {
-                    return res;
-                }
-            }
-        }
-    }
-
-    private class StatementScanner implements CloseableIteration<Statement, SailException> {
-
-        private final Resource subj;
-        private final IRI pred;
-        private final Value obj;
-        private final byte[] subjHash, predHash;
-        protected final List<Resource> contextsList;
-        protected Iterator<Resource> contexts;
-        protected byte[] objHash;
-        private ResultScanner rs = null;
-        private final long endTime;
-        private Statement next = null;
-        private Iterator<Statement> iter = null;
-
-        public StatementScanner(long startTime, Resource subj, IRI pred, Value obj, Resource...contexts) throws SailException {
-            this.subj = subj;
-            this.pred = pred;
-            this.obj = obj;
-            this.subjHash = HalyardTableUtils.hashKey(subj);
-            this.predHash = HalyardTableUtils.hashKey(pred);
-            this.objHash = HalyardTableUtils.hashKey(obj);
-            this.contextsList = Arrays.asList(normalizeContexts(contexts));
-            this.contexts = contextsList.iterator();
-            this.endTime = startTime + (1000l * evaluationTimeout);
-            LOG.log(Level.FINEST, "New StatementScanner {0} {1} {2} {3}", new Object[]{subj, pred, obj, contextsList});
-        }
-
-        protected Result nextResult() throws IOException { //gets the next result to consider from the HBase Scan
-            while (true) {
-                if (rs == null) {
-                    if (contexts.hasNext()) {
-
-                        //build a ResultScanner from an HBase Scan that finds potential matches
-                        rs = table.getScanner(HalyardTableUtils.scan(subjHash, predHash, objHash, HalyardTableUtils.hashKey(contexts.next())));
-                    } else {
-                        return null;
-                    }
-                }
-                Result res = rs.next();
-                if (ticker != null) ticker.tick(); //sends a tick for keep alive purposes
-                if (res == null) { // no more results from this ResultScanner, close and clean up.
-                    rs.close();
-                    rs = null;
-                } else {
-                    return res;
-                }
-            }
-        }
-
-        @Override
-        public void close() throws SailException {
-            if (rs != null) {
-                rs.close();
-            }
-        }
-
-        @Override
-        public synchronized boolean hasNext() throws SailException {
-            if (evaluationTimeout > 0 && System.currentTimeMillis() > endTime) {
-                throw new SailException("Statements scanning exceeded specified timeout " + evaluationTimeout + "s");
-            }
-            if (next == null) try { //try and find the next result
-                while (true) {
-                    if (iter == null) {
-                        Result res = nextResult();
-                        if (res == null) {
-                            return false; //no more Results
-                        } else {
-                            iter = HalyardTableUtils.parseStatements(res, getValueFactory()).iterator();
-                        }
-                    }
-                    while (iter.hasNext()) {
-                        Statement s = iter.next();
-                        if ((subj == null || subj.equals(s.getSubject())) && (pred == null || pred.equals(s.getPredicate())) && (obj == null || obj.equals(s.getObject()))) {
-                            next = s;  //cache the next statement which will be returned with a call to next().
-                            return true; //there is another statement
-                        }
-                    }
-                    iter = null;
-                }
-            } catch (IOException e) {
-                throw new SailException(e);
-            } else {
-                return true;
-            }
-        }
-
-        @Override
-        public synchronized Statement next() throws SailException {
-            if (hasNext()) { //return the next statement and set next to null so it can be refilled by the next call to hasNext()
-                Statement st = next;
-                next = null;
-                return st;
-            } else {
-                throw new NoSuchElementException();
-            }
-        }
-
-        @Override
-        public void remove() throws SailException {
-            throw new UnsupportedOperationException();
-        }
     }
 }

--- a/sail/src/main/java/com/msd/gin/halyard/sail/HBaseSailConnection.java
+++ b/sail/src/main/java/com/msd/gin/halyard/sail/HBaseSailConnection.java
@@ -1,0 +1,713 @@
+/*
+ * Copyright 2016 Merck Sharp & Dohme Corp. a subsidiary of Merck & Co.,
+ * Inc., Kenilworth, NJ, USA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.msd.gin.halyard.sail;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Table;
+import org.eclipse.rdf4j.IsolationLevel;
+import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
+import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
+import org.eclipse.rdf4j.common.iteration.TimeLimitIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+import org.eclipse.rdf4j.model.vocabulary.SD;
+import org.eclipse.rdf4j.model.vocabulary.VOID;
+import org.eclipse.rdf4j.query.Binding;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.IncompatibleOperationException;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.FunctionCall;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.ValueConstant;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.BindingAssigner;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.CompareOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.ConjunctiveConstraintSplitter;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.ConstantOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.DisjunctiveConstraintOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.IterativeEvaluationOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.OrderLimitOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryModelNormalizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.SameTermFilterOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.UnknownSailTransactionStateException;
+import org.eclipse.rdf4j.sail.UpdateContext;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import com.msd.gin.halyard.common.HalyardTableUtils;
+import com.msd.gin.halyard.optimizers.HalyardEvaluationStatistics;
+import com.msd.gin.halyard.optimizers.HalyardFilterOptimizer;
+import com.msd.gin.halyard.optimizers.HalyardQueryJoinOptimizer;
+import com.msd.gin.halyard.sail.HBaseSail.ConnectionFactory;
+import com.msd.gin.halyard.strategy.HalyardEvaluationStrategy;
+
+public class HBaseSailConnection implements SailConnection {
+    private static final Logger LOG = Logger.getLogger(HBaseSailConnection.class.getName());
+
+    private static final int ELASTIC_RESULT_SIZE = 10000;
+
+    private final HBaseSail sail;
+	private Table table;
+	private BufferedMutator mutator;
+
+    public HBaseSailConnection(HBaseSail sail) {
+    	this.sail = sail;
+		// tables are lightweight but not thread-safe so get a new instance per sail
+		// connection
+    	this.table = sail.getTable();
+    }
+
+    private BufferedMutator getBufferedMutator() {
+    	if (mutator == null) {
+    		mutator = sail.getBufferedMutator(table);
+    	}
+    	return mutator;
+    }
+
+    @Override
+    public boolean isOpen() throws SailException {
+        return table != null;  //if the table exists the table is open
+    }
+
+    @Override
+    public void close() throws SailException {
+    	commit();
+		if (table != null) {
+			try {
+				table.close();
+				table = null;
+			} catch (IOException e) {
+				throw new SailException(e);
+			}
+		}
+    }
+
+    //evaluate queries/ subqueries
+    @Override
+    public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings, final boolean includeInferred) throws SailException {
+        LOG.log(Level.FINE, "Evaluated TupleExpr before optimizers:\n{0}", tupleExpr);
+        tupleExpr = tupleExpr.clone();
+        if (!(tupleExpr instanceof QueryRoot)) {
+            // Add a dummy root node to the tuple expressions to allow the
+            // optimizers to modify the actual root node
+            tupleExpr = new QueryRoot(tupleExpr);
+        }
+
+        final long startTime = System.currentTimeMillis();
+
+        TripleSource source = new TripleSource() {
+            @Override
+            public CloseableIteration<? extends Statement, QueryEvaluationException> getStatements(Resource subj, IRI pred, Value obj, Resource... contexts) throws QueryEvaluationException {
+                try {
+                    return new ExceptionConvertingIteration<Statement, QueryEvaluationException>(createScanner(startTime, subj, pred, obj, contexts)) {
+                        @Override
+                        protected QueryEvaluationException convert(Exception e) {
+                            return new QueryEvaluationException(e);
+                        }
+
+                    };
+                } catch (SailException ex) {
+                    throw new QueryEvaluationException(ex);
+                }
+            }
+
+            @Override
+            public ValueFactory getValueFactory() {
+                return sail.getValueFactory();
+            }
+        };
+
+        EvaluationStrategy strategy = sail.pushStrategy ? new HalyardEvaluationStrategy(source, dataset, sail, sail.evaluationTimeout) : new StrictEvaluationStrategy(source, dataset, sail);
+
+        new BindingAssigner().optimize(tupleExpr, dataset, bindings);
+        new ConstantOptimizer(strategy).optimize(tupleExpr, dataset, bindings);
+        new CompareOptimizer().optimize(tupleExpr, dataset, bindings);
+        new ConjunctiveConstraintSplitter().optimize(tupleExpr, dataset, bindings);
+        new DisjunctiveConstraintOptimizer().optimize(tupleExpr, dataset, bindings);
+        new SameTermFilterOptimizer().optimize(tupleExpr, dataset, bindings);
+        new QueryModelNormalizer().optimize(tupleExpr, dataset, bindings);
+        try {
+            //seach for presence of HALYARD.SEARCH_TYPE or HALYARD.PARALLEL_SPLIT_FUNCTION within the query
+            tupleExpr.visit(new AbstractQueryModelVisitor<IncompatibleOperationException>(){
+                private void checkForSearchType(Value val) {
+                    if (HALYARD.SEARCH_TYPE.equals(val) ||((val instanceof Literal) && HALYARD.SEARCH_TYPE.equals(((Literal)val).getDatatype()))) {
+                        throw new IncompatibleOperationException();
+                    }
+                }
+                @Override
+                public void meet(ValueConstant node) throws RuntimeException {
+                    checkForSearchType(node.getValue());
+                    super.meet(node);
+                }
+                @Override
+                public void meet(Var node) throws RuntimeException {
+                    if (node.hasValue()) {
+                        checkForSearchType(node.getValue());
+                    }
+                    super.meet(node);
+                }
+                @Override
+                public void meet(FunctionCall node) throws IncompatibleOperationException {
+                    if (HALYARD.PARALLEL_SPLIT_FUNCTION.toString().equals(node.getURI())) {
+                        throw new IncompatibleOperationException();
+                    }
+                    super.meet(node);
+                }
+                @Override
+                public void meet(BindingSetAssignment node) throws RuntimeException {
+                    for (BindingSet bs : node.getBindingSets()) {
+                        for (Binding b : bs) {
+                            checkForSearchType(b.getValue());
+                        }
+                    }
+                    super.meet(node);
+                }
+            });
+            new HalyardQueryJoinOptimizer(sail.statistics).optimize(tupleExpr, dataset, bindings);
+        } catch (IncompatibleOperationException ioe) {
+            //skip HalyardQueryJoinOptimizer when  HALYARD.PARALLEL_SPLIT_FUNCTION or HALYARD.SEARCH_TYPE is present
+        }
+        // new SubSelectJoinOptimizer().optimize(tupleExpr, dataset, bindings);
+        new IterativeEvaluationOptimizer().optimize(tupleExpr, dataset, bindings);
+        new HalyardFilterOptimizer().optimize(tupleExpr, dataset, bindings); //apply filter optimizer twice (before and after Joins and Unions shaking)
+        new OrderLimitOptimizer().optimize(tupleExpr, dataset, bindings);
+        LOG.log(Level.FINE, "Evaluated TupleExpr after optimization:\n{0}", tupleExpr);
+        try {
+        		//evaluate the expression against the TripleSource according to the EvaluationStrategy.
+            CloseableIteration<BindingSet, QueryEvaluationException> iter = evaluateInternal(strategy, tupleExpr);
+            return sail.evaluationTimeout <= 0 ? iter : new TimeLimitIteration<BindingSet, QueryEvaluationException>(iter, 1000l * sail.evaluationTimeout) {
+                @Override
+                protected void throwInterruptedException() throws QueryEvaluationException {
+                    throw new QueryEvaluationException("Query evaluation exceeded specified timeout " + sail.evaluationTimeout + "s");
+                }
+            };
+        } catch (QueryEvaluationException ex) {
+            throw new SailException(ex);
+        }
+    }
+
+    protected CloseableIteration<BindingSet, QueryEvaluationException> evaluateInternal(EvaluationStrategy strategy, TupleExpr tupleExpr) {
+        return strategy.evaluate(tupleExpr, EmptyBindingSet.getInstance());
+    }
+
+    @Override
+    public CloseableIteration<? extends Resource, SailException> getContextIDs() throws SailException {
+
+        //generate an iterator over the identifiers of the contexts available in Halyard.
+        final CloseableIteration<? extends Statement, SailException> scanner = getStatements(HALYARD.STATS_ROOT_NODE, SD.NAMED_GRAPH_PROPERTY, null, true, HALYARD.STATS_GRAPH_CONTEXT);
+        return new CloseableIteration<Resource, SailException>() {
+            @Override
+            public void close() throws SailException {
+                scanner.close();
+            }
+
+            @Override
+            public boolean hasNext() throws SailException {
+                return scanner.hasNext();
+            }
+
+            @Override
+            public Resource next() throws SailException {
+                return (IRI)scanner.next().getObject();
+            }
+
+            @Override
+            public void remove() throws SailException {
+                throw new UnsupportedOperationException();
+            }
+
+        };
+    }
+
+    @Override
+    public CloseableIteration<? extends Statement, SailException> getStatements(Resource subj, IRI pred, Value obj, boolean includeInferred, Resource... contexts) throws SailException {
+        return createScanner(System.currentTimeMillis(), subj, pred, obj, contexts);
+    }
+
+    private StatementScanner createScanner(long startTime, Resource subj, IRI pred, Value obj, Resource...contexts) throws SailException {
+        if ((obj instanceof Literal) && (HALYARD.SEARCH_TYPE.equals(((Literal)obj).getDatatype()))) {
+            return new LiteralSearchStatementScanner(startTime, subj, pred, obj.stringValue(), contexts);
+        } else {
+            return new StatementScanner(startTime, subj, pred, obj, contexts);
+        }
+    }
+
+    @Override
+    public synchronized long size(Resource... contexts) throws SailException {
+        long size = 0;
+        if (contexts != null && contexts.length > 0 && contexts[0] != null) {
+            for (Resource ctx : contexts) {
+            		//examine the VOID statistics for the count of triples in this context
+                try (CloseableIteration<? extends Statement, SailException> scanner = getStatements(ctx, VOID.TRIPLES, null, true, HALYARD.STATS_GRAPH_CONTEXT)) {
+                    if (scanner.hasNext()) {
+                        size += ((Literal)scanner.next().getObject()).longValue();
+                    }
+                    if (scanner.hasNext()) {
+                        throw new SailException("Multiple different values exist in VOID statistics for context: "+ctx.stringValue()+". Considering removing and recomputing statistics");
+                    }
+                }
+            }
+        } else {
+            try (CloseableIteration<? extends Statement, SailException> scanner = getStatements(HALYARD.STATS_ROOT_NODE, VOID.TRIPLES, null, true, HALYARD.STATS_GRAPH_CONTEXT)) {
+                if (scanner.hasNext()) {
+                    size += ((Literal)scanner.next().getObject()).longValue();
+                }
+                if (scanner.hasNext()) {
+                    throw new SailException("Multiple different values exist in VOID statistics. Considering removing and recomputing statistics");
+                }
+            }
+        }
+        // try to count it manually if there are no stats and there is a specific timeout
+        if (size == 0 && sail.evaluationTimeout > 0) try (CloseableIteration<? extends Statement, SailException> scanner = getStatements(null, null, null, true, contexts)) {
+            while (scanner.hasNext()) {
+                scanner.next();
+                size++;
+            }
+        }
+        return size;
+    }
+
+    @Override
+    public void begin() throws SailException { //transactions are not supported
+    }
+
+    @Override
+    public void begin(IsolationLevel level) throws UnknownSailTransactionStateException, SailException {
+        if (level != null && level != IsolationLevels.NONE) {
+            throw new UnknownSailTransactionStateException("Isolation level " + level + " is not compatible with this HBaseSail");
+        }
+    }
+
+    @Override
+    public void flush() throws SailException {
+    }
+
+    @Override
+    public void prepare() throws SailException {
+    }
+
+    @Override
+    public void commit() throws SailException {
+    	if (mutator != null) {
+	    	try {
+				mutator.flush();
+			} catch (IOException e) {
+				throw new SailException(e);
+			}
+    	}
+    }
+
+    @Override
+    public void rollback() throws SailException {
+    }
+
+    @Override
+    public boolean isActive() throws UnknownSailTransactionStateException {
+        return true;
+    }
+
+    @Override
+    public void addStatement(UpdateContext op, Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
+        addStatement(subj, pred, obj, contexts);
+    }
+
+    protected long getDefaultTimeStamp() {
+        return System.currentTimeMillis();
+    }
+
+	protected final HalyardEvaluationStatistics getStatistics() {
+		return sail.statistics;
+	}
+
+    @Override
+    public void addStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
+        long timestamp = getDefaultTimeStamp();
+		addStatementInternal(subj, pred, obj, contexts, timestamp);
+    }
+
+    private void checkWritable() {
+        if (!sail.isWritable()) throw new SailException(sail.tableName + " is read only");
+    }
+
+	protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource[] contexts, long timestamp) throws SailException {
+    	checkWritable();
+        try {
+			for (Resource ctx : normalizeContexts(contexts)) {
+				for (KeyValue kv : HalyardTableUtils.toKeyValues(subj, pred, obj, ctx, false, timestamp)) { // serialize the key value pairs relating to the statement in HBase
+					put(kv);
+				}
+			}
+        } catch (IOException e) {
+            throw new SailException(e);
+        }
+    }
+
+	protected void put(KeyValue kv) throws IOException {
+		getBufferedMutator().mutate(new Put(kv.getRowArray(), kv.getRowOffset(), kv.getRowLength(), kv.getTimestamp()).add(kv));
+    }
+
+    @Override
+    public void removeStatement(UpdateContext op, Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
+		// should we be defensive about nulls for subj, pre and obj? removeStatements is
+		// where you would use nulls, not here.
+
+        long timestamp = getDefaultTimeStamp();
+		removeStatementInternal(op, subj, pred, obj, contexts, timestamp);
+    }
+
+	protected void removeStatementInternal(UpdateContext op, Resource subj, IRI pred, Value obj, Resource[] contexts, long timestamp) throws SailException {
+		checkWritable();
+		try {
+			for (Resource ctx : normalizeContexts(contexts)) {
+				for (KeyValue kv : HalyardTableUtils.toKeyValues(subj, pred, obj, ctx, true, timestamp)) { // calculate the kv's corresponding to the quad (or triple)
+					delete(kv);
+				}
+			}
+		} catch (IOException e) {
+			throw new SailException(e);
+		}
+	}
+
+	protected void delete(KeyValue kv) throws IOException {
+		getBufferedMutator().mutate(new Delete(kv.getRowArray(), kv.getRowOffset(), kv.getRowLength()).addDeleteMarker(kv));
+    }
+
+    @Override
+    public void removeStatements(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
+    	checkWritable();
+        contexts = normalizeContexts(contexts);
+        if (subj == null && pred == null && obj == null && contexts[0] == null) {
+            clearAll();
+        } else {
+            try (CloseableIteration<? extends Statement, SailException> iter = getStatements(subj, pred, obj, true, contexts)) {
+                while (iter.hasNext()) {
+                    Statement st = iter.next();
+                    removeStatement(null, st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean pendingRemovals() {
+        return false;
+    }
+
+    @Override
+    public void startUpdate(UpdateContext op) throws SailException {
+    }
+
+    @Override
+    public void endUpdate(UpdateContext op) throws SailException {
+    }
+
+    @Override
+    public void clear(Resource... contexts) throws SailException {
+        removeStatements(null, null, null, contexts); //remove all statements in the contexts.
+        commit();
+    }
+
+    private void clearAll() throws SailException {
+    	checkWritable();
+        try {
+			HalyardTableUtils.truncateTable(sail.hConnection, table); // delete all triples, the whole DB but retains splits!
+        } catch (IOException ex) {
+            throw new SailException(ex);
+        }
+    }
+
+    @Override
+    public String getNamespace(String prefix) throws SailException {
+        Namespace namespace = sail.namespaces.get(prefix);
+        return (namespace == null) ? null : namespace.getName();
+    }
+
+    @Override
+    public CloseableIteration<? extends Namespace, SailException> getNamespaces() {
+        return new CloseableIteratorIteration<>(sail.namespaces.values().iterator());
+    }
+
+    @Override
+    public void setNamespace(String prefix, String name) throws SailException {
+        sail.namespaces.put(prefix, new SimpleNamespace(prefix, name));
+        ValueFactory vf = sail.getValueFactory();
+        try {
+            removeStatements(null, HALYARD.NAMESPACE_PREFIX_PROPERTY, vf.createLiteral(prefix));
+			addStatementInternal(vf.createIRI(name), HALYARD.NAMESPACE_PREFIX_PROPERTY, vf.createLiteral(prefix), new Resource[] { HALYARD.SYSTEM_GRAPH_CONTEXT }, getDefaultTimeStamp());
+        } catch (SailException e) {
+            LOG.log(Level.WARNING, "Namespace prefix could not be presisted due to an exception", e);
+        }
+    }
+
+    @Override
+    public void removeNamespace(String prefix) throws SailException {
+        ValueFactory vf = sail.getValueFactory();
+        sail.namespaces.remove(prefix);
+        try {
+            removeStatements(null, HALYARD.NAMESPACE_PREFIX_PROPERTY, vf.createLiteral(prefix));
+        } catch (SailException e) {
+            LOG.log(Level.WARNING, "Namespace prefix could not be removed due to an exception", e);
+        }
+    }
+
+    @Override
+    public void clearNamespaces() throws SailException {
+        try {
+            removeStatements(null, HALYARD.NAMESPACE_PREFIX_PROPERTY, null);
+        } catch (SailException e) {
+            LOG.log(Level.WARNING, "Namespaces could not be cleared due to an exception", e);
+        }
+        sail.namespaces.clear();
+    }
+
+    private static final Map <String, List<byte[]>> SEARCH_CACHE = new WeakHashMap<>();
+
+    //Scans the Halyard table for statements that match the specified pattern
+    private class LiteralSearchStatementScanner extends StatementScanner {
+
+        Iterator<byte[]> objectHashes = null;
+        private final String literalSearchQuery;
+
+        public LiteralSearchStatementScanner(long startTime, Resource subj, IRI pred, String literalSearchQuery, Resource... contexts) throws SailException {
+            super(startTime, subj, pred, null, contexts);
+            if (sail.elasticIndexURL == null || sail.elasticIndexURL.length() == 0) {
+                throw new SailException("ElasticSearch Index URL is not properly configured.");
+            }
+            this.literalSearchQuery = literalSearchQuery;
+        }
+
+        @Override
+        protected Result nextResult() throws IOException {
+            while (true) {
+                if (objHash == null) {
+                    if (objectHashes == null) { //perform ES query and parse results
+                        synchronized (SEARCH_CACHE) {
+                            List<byte[]> objectHashesList = SEARCH_CACHE.get(literalSearchQuery);
+                            if (objectHashesList == null) {
+                                objectHashesList = new ArrayList<>();
+                                HttpURLConnection http = (HttpURLConnection)(new URL(sail.elasticIndexURL + "/_search").openConnection());
+                                try {
+                                    http.setRequestMethod("POST");
+                                    http.setDoOutput(true);
+                                    http.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+                                    http.connect();
+                                    try (PrintStream out = new PrintStream(http.getOutputStream(), true, "UTF-8")) {
+                                        out.print("{\"query\":{\"query_string\":{\"query\":" + JSONObject.quote(literalSearchQuery) + "}},\"_source\":false,\"stored_fields\":\"_id\",\"size\":" + ELASTIC_RESULT_SIZE + "}");
+                                    }
+                                    int response = http.getResponseCode();
+                                    String msg = http.getResponseMessage();
+                                    if (response != 200) {
+                                        LOG.info("ElasticSearch error response: " + msg + " on query: " + literalSearchQuery);
+                                    } else {
+                                        try (InputStreamReader isr = new InputStreamReader(http.getInputStream(), "UTF-8")) {
+                                            JSONArray hits = new JSONObject(new JSONTokener(isr)).getJSONObject("hits").getJSONArray("hits");
+                                            for (int i=0; i<hits.length(); i++) {
+                                                objectHashesList.add(Hex.decodeHex(hits.getJSONObject(i).getString("_id").toCharArray()));
+                                            }
+                                        }
+                                        SEARCH_CACHE.put(new String(literalSearchQuery), objectHashesList);
+                                    }
+                                } catch (JSONException | DecoderException ex) {
+                                    throw new IOException(ex);
+                                } finally {
+                                    http.disconnect();
+                                }
+                            }
+                            objectHashes = objectHashesList.iterator();
+                        }
+                    }
+                    if (objectHashes.hasNext()) {
+                        objHash = objectHashes.next();
+                    } else {
+                        return null;
+                    }
+                    contexts = contextsList.iterator(); //reset iterator over contexts
+                }
+                Result res = super.nextResult();
+                if (res == null) {
+                    objHash = null;
+                } else {
+                    return res;
+                }
+            }
+        }
+    }
+
+    private class StatementScanner implements CloseableIteration<Statement, SailException> {
+
+        private final Resource subj;
+        private final IRI pred;
+        private final Value obj;
+        private final byte[] subjHash, predHash;
+        protected final List<Resource> contextsList;
+        protected Iterator<Resource> contexts;
+        protected byte[] objHash;
+        private ResultScanner rs = null;
+        private final long endTime;
+        private Statement next = null;
+        private Iterator<Statement> iter = null;
+
+        public StatementScanner(long startTime, Resource subj, IRI pred, Value obj, Resource...contexts) throws SailException {
+            this.subj = subj;
+            this.pred = pred;
+            this.obj = obj;
+            this.subjHash = HalyardTableUtils.hashKey(subj);
+            this.predHash = HalyardTableUtils.hashKey(pred);
+            this.objHash = HalyardTableUtils.hashKey(obj);
+            this.contextsList = Arrays.asList(normalizeContexts(contexts));
+            this.contexts = contextsList.iterator();
+            this.endTime = startTime + (1000l * sail.evaluationTimeout);
+            LOG.log(Level.FINEST, "New StatementScanner {0} {1} {2} {3}", new Object[]{subj, pred, obj, contextsList});
+        }
+
+        protected Result nextResult() throws IOException { //gets the next result to consider from the HBase Scan
+            while (true) {
+                if (rs == null) {
+                    if (contexts.hasNext()) {
+
+                        //build a ResultScanner from an HBase Scan that finds potential matches
+                        rs = table.getScanner(HalyardTableUtils.scan(subjHash, predHash, objHash, HalyardTableUtils.hashKey(contexts.next())));
+                    } else {
+                        return null;
+                    }
+                }
+                Result res = rs.next();
+                if (sail.ticker != null) sail.ticker.tick(); //sends a tick for keep alive purposes
+                if (res == null) { // no more results from this ResultScanner, close and clean up.
+                    rs.close();
+                    rs = null;
+                } else {
+                    return res;
+                }
+            }
+        }
+
+        @Override
+        public void close() throws SailException {
+            if (rs != null) {
+                rs.close();
+            }
+        }
+
+        @Override
+        public synchronized boolean hasNext() throws SailException {
+            if (sail.evaluationTimeout > 0 && System.currentTimeMillis() > endTime) {
+                throw new SailException("Statements scanning exceeded specified timeout " + sail.evaluationTimeout + "s");
+            }
+            if (next == null) try { //try and find the next result
+                while (true) {
+                    if (iter == null) {
+                        Result res = nextResult();
+                        if (res == null) {
+                            return false; //no more Results
+                        } else {
+                            iter = HalyardTableUtils.parseStatements(res, sail.getValueFactory()).iterator();
+                        }
+                    }
+                    while (iter.hasNext()) {
+                        Statement s = iter.next();
+                        if ((subj == null || subj.equals(s.getSubject())) && (pred == null || pred.equals(s.getPredicate())) && (obj == null || obj.equals(s.getObject()))) {
+                            next = s;  //cache the next statement which will be returned with a call to next().
+                            return true; //there is another statement
+                        }
+                    }
+                    iter = null;
+                }
+            } catch (IOException e) {
+                throw new SailException(e);
+            } else {
+                return true;
+            }
+        }
+
+        @Override
+        public synchronized Statement next() throws SailException {
+            if (hasNext()) { //return the next statement and set next to null so it can be refilled by the next call to hasNext()
+                Statement st = next;
+                next = null;
+                return st;
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+
+        @Override
+        public void remove() throws SailException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    //generates a Resource[] from 0 or more Resources
+    protected static Resource[] normalizeContexts(Resource... contexts) {
+        if (contexts == null || contexts.length == 0) {
+            return new Resource[] {null};
+        } else {
+            return contexts;
+        }
+    }
+
+	public static class Factory implements ConnectionFactory {
+		public static final ConnectionFactory INSTANCE = new Factory();
+
+		@Override
+		public SailConnection createConnection(HBaseSail sail) {
+			return new HBaseSailConnection(sail);
+		}
+	}
+}

--- a/sail/src/main/java/com/msd/gin/halyard/sail/HalyardStatsBasedStatementPatternCardinalityCalculator.java
+++ b/sail/src/main/java/com/msd/gin/halyard/sail/HalyardStatsBasedStatementPatternCardinalityCalculator.java
@@ -16,24 +16,25 @@
  */
 package com.msd.gin.halyard.sail;
 
-import com.msd.gin.halyard.common.HalyardTableUtils;
-import com.msd.gin.halyard.optimizers.HalyardEvaluationStatistics;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.VOID;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
+
+import com.msd.gin.halyard.common.HalyardTableUtils;
+import com.msd.gin.halyard.optimizers.HalyardEvaluationStatistics;
 
 /**
  *

--- a/sail/src/main/java/com/msd/gin/halyard/sail/SailFederatedService.java
+++ b/sail/src/main/java/com/msd/gin/halyard/sail/SailFederatedService.java
@@ -1,0 +1,79 @@
+package com.msd.gin.halyard.sail;
+
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.Service;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedService;
+import org.eclipse.rdf4j.repository.sparql.query.InsertBindingSetCursor;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailConnection;
+
+import com.msd.gin.halyard.strategy.HalyardEvaluationStrategy.ServiceRoot;
+
+public class SailFederatedService implements FederatedService {
+	private final Sail sail;
+	private boolean initialized;
+	private SailConnection conn;
+
+	public SailFederatedService(Sail sail) {
+		this.sail = sail;
+	}
+
+	public Sail getSail() {
+		return sail;
+	}
+
+	@Override
+	public void initialize() throws QueryEvaluationException {
+		if (!initialized) {
+			sail.initialize();
+			initialized = true;
+		}
+	}
+
+	@Override
+	public boolean isInitialized() {
+		return initialized;
+	}
+
+	@Override
+	public void shutdown() throws QueryEvaluationException {
+		if (conn != null) {
+			conn.close();
+			conn = null;
+		}
+		sail.shutDown();
+	}
+
+	@Override
+	public boolean ask(Service service, BindingSet bindings, String baseUri) throws QueryEvaluationException {
+		try (CloseableIteration<? extends BindingSet, QueryEvaluationException> res = getConnection()
+				.evaluate(new ServiceRoot(service.getArg()), null, bindings, true)) {
+			return res.hasNext();
+		}
+	}
+
+	@Override
+	public CloseableIteration<BindingSet, QueryEvaluationException> select(Service service, Set<String> projectionVars,
+			BindingSet bindings, String baseUri) throws QueryEvaluationException {
+		CloseableIteration<? extends BindingSet, QueryEvaluationException> iter = getConnection().evaluate(new ServiceRoot(service.getArg()), null, bindings, true);
+		return new InsertBindingSetCursor((CloseableIteration<BindingSet, QueryEvaluationException>) iter, bindings);
+	}
+
+	@Override
+	public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(Service service,
+			CloseableIteration<BindingSet, QueryEvaluationException> bindings, String baseUri)
+			throws QueryEvaluationException {
+		throw new UnsupportedOperationException();
+	}
+
+	protected SailConnection getConnection() {
+		if (conn == null) {
+			conn = sail.getConnection();
+		}
+		return conn;
+	}
+}

--- a/sail/src/test/java/com/msd/gin/halyard/sail/HBaseSailAddRemoveTest.java
+++ b/sail/src/test/java/com/msd/gin/halyard/sail/HBaseSailAddRemoveTest.java
@@ -16,22 +16,28 @@
  */
 package com.msd.gin.halyard.sail;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collection;
+
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.junit.AfterClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
 
 /**
  *
@@ -83,36 +89,40 @@ public class HBaseSailAddRemoveTest {
 
     @Test
     public void testAddAndRemoveExplicitStatements() throws Exception {
-        explicitSail.addStatement(null, SUBJ, PRED, OBJ);
-        explicitSail.addStatement(null, SUBJ, PRED, OBJ, CONTEXT);
-        explicitSail.commit();
-        CloseableIteration<? extends Statement, SailException> iter;
-        iter = explicitSail.getStatements(null, null, null, true);
-        assertTrue(iter.hasNext());
-        iter.next();
-        assertTrue(iter.hasNext());
-        Statement st = iter.next();
-        assertFalse(iter.hasNext());
-        iter.close();
-        assertEquals(SUBJ, st.getSubject());
-        assertEquals(PRED, st.getPredicate());
-        assertEquals(OBJ, st.getObject());
-        iter = explicitSail.getStatements(null, null, null, true, CONTEXT);
-        assertTrue(iter.hasNext());
-        st = iter.next();
-        assertFalse(iter.hasNext());
-        iter.close();
-        assertEquals(SUBJ, st.getSubject());
-        assertEquals(PRED, st.getPredicate());
-        assertEquals(OBJ, st.getObject());
-        assertEquals(CONTEXT, st.getContext());
-        explicitSail.removeStatements(subj, pred, obj, CONTEXT);
-        iter = explicitSail.getStatements(null, null, null, true);
-        assertTrue(iter.hasNext());
-        iter.close();
-        explicitSail.removeStatements(subj, pred, obj);
-        iter = explicitSail.getStatements(null, null, null, true);
-        assertFalse(iter.hasNext());
-        iter.close();
+		try (SailConnection conn = explicitSail.getConnection()) {
+			conn.addStatement(null, SUBJ, PRED, OBJ);
+			conn.addStatement(null, SUBJ, PRED, OBJ, CONTEXT);
+			conn.commit();
+			CloseableIteration<? extends Statement, SailException> iter;
+			iter = conn.getStatements(null, null, null, true);
+			assertTrue(iter.hasNext());
+			iter.next();
+			assertTrue(iter.hasNext());
+			Statement st = iter.next();
+			assertFalse(iter.hasNext());
+			iter.close();
+			assertEquals(SUBJ, st.getSubject());
+			assertEquals(PRED, st.getPredicate());
+			assertEquals(OBJ, st.getObject());
+			iter = conn.getStatements(null, null, null, true, CONTEXT);
+			assertTrue(iter.hasNext());
+			st = iter.next();
+			assertFalse(iter.hasNext());
+			iter.close();
+			assertEquals(SUBJ, st.getSubject());
+			assertEquals(PRED, st.getPredicate());
+			assertEquals(OBJ, st.getObject());
+			assertEquals(CONTEXT, st.getContext());
+			conn.removeStatements(subj, pred, obj, CONTEXT);
+			conn.commit();
+			iter = conn.getStatements(null, null, null, true);
+			assertTrue(iter.hasNext());
+			iter.close();
+			conn.removeStatements(subj, pred, obj);
+			conn.commit();
+			iter = conn.getStatements(null, null, null, true);
+			assertFalse(iter.hasNext());
+			iter.close();
+		}
     }
 }

--- a/sail/src/test/java/com/msd/gin/halyard/sail/HBaseSailTest.java
+++ b/sail/src/test/java/com/msd/gin/halyard/sail/HBaseSailTest.java
@@ -16,37 +16,50 @@
  */
 package com.msd.gin.halyard.sail;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.common.HalyardTableUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.List;
 import java.util.Random;
-import org.apache.hadoop.conf.Configuration;
+
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
-import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SD;
 import org.eclipse.rdf4j.model.vocabulary.VOID;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.GraphQueryResult;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.UnknownSailTransactionStateException;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.common.HalyardTableUtils;
 
 /**
  *
@@ -54,36 +67,50 @@ import static org.junit.Assert.*;
  */
 public class HBaseSailTest {
 
-    @Test(expected = UnsupportedOperationException.class)
+	private Connection hconn;
+
+    @Before
+    public void setup() throws Exception {
+		hconn = HalyardTableUtils.getConnection(HBaseServerTestInstance.getInstanceConfig());
+    }
+
+    @After
+    public void teardown() throws Exception {
+		hconn.close();
+    }
+
+	@Test(expected = UnsupportedOperationException.class)
     public void testGetDataDir() throws Exception {
-        new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null).getDataDir();
+        new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null).getDataDir();
     }
 
     @Test
     public void testInitializeAndShutDown() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
-        assertFalse(sail.isOpen());
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
         sail.initialize();
-        assertTrue(sail.isOpen());
         sail.shutDown();
-        assertFalse(sail.isOpen());
+    }
+
+    @Test
+    public void testInitializeAndShutDownWithNoSharedConnection() throws Exception {
+        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
+        sail.initialize();
+        sail.shutDown();
     }
 
     @Test
     public void testIsWritable() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertableRW", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertableRW", true, 0, true, 0, null, null);
         sail.initialize();
-        HTableDescriptor desc = sail.table.getTableDescriptor();
+        HTableDescriptor desc = sail.getTable().getTableDescriptor();
         assertTrue(sail.isWritable());
         sail.shutDown();
-        try (Connection con = ConnectionFactory.createConnection(HBaseServerTestInstance.getInstanceConfig())) {
-            try (Admin ha = con.getAdmin()) {
-                desc = new HTableDescriptor(desc);
-                desc.setReadOnly(true);
-                ha.modifyTable(desc.getTableName(), desc);
-            }
+        try (Admin ha = hconn.getAdmin()) {
+            desc = new HTableDescriptor(desc);
+            desc.setReadOnly(true);
+            ha.modifyTable(desc.getTableName(), desc);
         }
-        sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), desc.getNameAsString(), true, 0, true, 0, null, null);
+        sail = new HBaseSail(hconn, desc.getNameAsString(), true, 0, true, 0, null, null);
         sail.initialize();
         assertFalse(sail.isWritable());
         sail.shutDown();
@@ -91,19 +118,19 @@ public class HBaseSailTest {
 
     @Test(expected = SailException.class)
     public void testWriteToReadOnly() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertableRO", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertableRO", true, 0, true, 0, null, null);
         sail.initialize();
         try {
-            HTableDescriptor desc = sail.table.getTableDescriptor();
-            try (Connection con = ConnectionFactory.createConnection(HBaseServerTestInstance.getInstanceConfig())) {
-                try (Admin ha = con.getAdmin()) {
-                    desc = new HTableDescriptor(desc);
-                    desc.setReadOnly(true);
-                    ha.modifyTable(desc.getTableName(), desc);
-                }
+            HTableDescriptor desc = sail.getTable().getTableDescriptor();
+            try (Admin ha = hconn.getAdmin()) {
+                desc = new HTableDescriptor(desc);
+                desc.setReadOnly(true);
+                ha.modifyTable(desc.getTableName(), desc);
             }
             ValueFactory vf = SimpleValueFactory.getInstance();
-            sail.addStatement(vf.createIRI("http://whatever/subj"), vf.createIRI("http://whatever/pred"), vf.createLiteral("whatever"));
+			try (SailConnection conn = sail.getConnection()) {
+            	conn.addStatement(vf.createIRI("http://whatever/subj"), vf.createIRI("http://whatever/pred"), vf.createLiteral("whatever"));
+            }
         } finally {
             sail.shutDown();
         }
@@ -111,110 +138,155 @@ public class HBaseSailTest {
 
     @Test
     public void testGetConnection() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
-        assertSame(sail, sail.getConnection());
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
+		try {
+			sail.initialize();
+			try (SailConnection conn = sail.getConnection()) {
+				assertTrue(conn.isOpen());
+			}
+		} finally {
+			sail.shutDown();
+		}
     }
 
     @Test
     public void testGetValueFactory() throws Exception {
-        assertSame(SimpleValueFactory.getInstance(), new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null).getValueFactory());
+        assertSame(SimpleValueFactory.getInstance(), new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null).getValueFactory());
     }
 
     @Test
     public void testGetSupportedIsolationLevels() throws Exception {
-        List<IsolationLevel> il = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null).getSupportedIsolationLevels();
+        List<IsolationLevel> il = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null).getSupportedIsolationLevels();
         assertEquals(1, il.size());
         assertTrue(il.contains(IsolationLevels.NONE));
     }
 
     @Test
     public void testGetDefaultIsolationLevel() throws Exception {
-        assertSame(IsolationLevels.NONE, new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null).getDefaultIsolationLevel());
+        assertSame(IsolationLevels.NONE, new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null).getDefaultIsolationLevel());
     }
 
     @Test
     public void testGetContextIDs() throws Exception {
         ValueFactory vf = SimpleValueFactory.getInstance();
-        Configuration cfg = HBaseServerTestInstance.getInstanceConfig();
-        HBaseSail sail = new HBaseSail(cfg, "whatevertablectx", true, 0, true, 0, null, null);
+		HBaseSail sail = new HBaseSail(hconn, "whatevertablectx", true, 0, true,
+				0, null, null);
         sail.initialize();
-        sail.addStatement(HALYARD.STATS_ROOT_NODE, SD.NAMED_GRAPH_PROPERTY, vf.createIRI("http://whatever/ctx"), HALYARD.STATS_GRAPH_CONTEXT);
-        sail.commit();
-        try (CloseableIteration<? extends Resource, SailException> ctxIt = sail.getContextIDs()) {
-            assertTrue(ctxIt.hasNext());
-            assertEquals("http://whatever/ctx", ctxIt.next().stringValue());
+		try (SailConnection conn = sail.getConnection()) {
+            conn.addStatement(HALYARD.STATS_ROOT_NODE, SD.NAMED_GRAPH_PROPERTY, vf.createIRI("http://whatever/ctx"), HALYARD.STATS_GRAPH_CONTEXT);
+            conn.commit();
+            try (CloseableIteration<? extends Resource, SailException> ctxIt = conn.getContextIDs()) {
+                assertTrue(ctxIt.hasNext());
+                assertEquals("http://whatever/ctx", ctxIt.next().stringValue());
+            }
         }
     }
 
     @Test
     public void testSize() throws Exception {
         ValueFactory vf = SimpleValueFactory.getInstance();
-        Configuration cfg = HBaseServerTestInstance.getInstanceConfig();
-        HBaseSail sail = new HBaseSail(cfg, "whatevertablesize", true, 0, true, 180, null, null);
+		HBaseSail sail = new HBaseSail(hconn, "whatevertablesize", true, 0, true,
+				180, null, null);
         sail.initialize();
-        assertEquals(0, sail.size());
-        assertEquals(0, sail.size(HALYARD.STATS_ROOT_NODE));
-        IRI iri = vf.createIRI("http://whatever/");
-        sail.addStatement(iri, iri, iri);
-        sail.commit();
-        assertEquals(1, sail.size());
-        sail.addStatement(HALYARD.STATS_ROOT_NODE, VOID.TRIPLES, vf.createLiteral(567), HALYARD.STATS_GRAPH_CONTEXT);
-        sail.commit();
-        assertEquals(567, sail.size());
-        assertEquals(567, sail.size(HALYARD.STATS_ROOT_NODE));
-        sail.addStatement(HALYARD.STATS_ROOT_NODE, VOID.TRIPLES, vf.createLiteral(568), HALYARD.STATS_GRAPH_CONTEXT);
-        sail.commit();
-        try {
-            sail.size();
-            fail("Expected SailException");
-        } catch (SailException se) {}
-        try {
-            sail.size(HALYARD.STATS_ROOT_NODE);
-            fail("Expected SailException");
-        } catch (SailException se) {}
+		try (SailConnection conn = sail.getConnection()) {
+            assertEquals(0, conn.size());
+            assertEquals(0, conn.size(HALYARD.STATS_ROOT_NODE));
+            IRI iri = vf.createIRI("http://whatever/");
+            conn.addStatement(iri, iri, iri);
+            conn.commit();
+            assertEquals(1, conn.size());
+            conn.addStatement(HALYARD.STATS_ROOT_NODE, VOID.TRIPLES, vf.createLiteral(567), HALYARD.STATS_GRAPH_CONTEXT);
+            conn.commit();
+            assertEquals(567, conn.size());
+            assertEquals(567, conn.size(HALYARD.STATS_ROOT_NODE));
+            conn.addStatement(HALYARD.STATS_ROOT_NODE, VOID.TRIPLES, vf.createLiteral(568), HALYARD.STATS_GRAPH_CONTEXT);
+            conn.commit();
+            try {
+            	conn.size();
+                fail("Expected SailException");
+            } catch (SailException se) {}
+            try {
+            	conn.size(HALYARD.STATS_ROOT_NODE);
+                fail("Expected SailException");
+            } catch (SailException se) {}
+        }
     }
 
     @Test(expected = UnknownSailTransactionStateException.class)
     public void testBegin() throws Exception {
-        new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null).begin(IsolationLevels.READ_COMMITTED);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
+		try {
+			sail.initialize();
+			try (SailConnection conn = sail.getConnection()) {
+				conn.begin(IsolationLevels.READ_COMMITTED);
+			}
+		} finally {
+			sail.shutDown();
+		}
     }
 
     @Test
     public void testRollback() throws Exception {
-        new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null).rollback();
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
+		try {
+			sail.initialize();
+			try (SailConnection conn = sail.getConnection()) {
+				conn.rollback();
+			}
+		} finally {
+			sail.shutDown();
+		}
     }
 
     @Test
     public void testIsActive() throws Exception {
-        assertTrue(new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null).isActive());
+    	HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
+		try {
+			sail.initialize();
+			try (SailConnection conn = sail.getConnection()) {
+				assertTrue(conn.isActive());
+			}
+		} finally {
+			sail.shutDown();
+		}
     }
 
     @Test
     public void testNamespaces() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
         sail.initialize();
-        assertFalse(sail.getNamespaces().hasNext());
-        sail.setNamespace("prefix", "http://whatever/namespace/");
+		try (SailConnection conn = sail.getConnection()) {
+        	assertFalse(conn.getNamespaces().hasNext());
+        	conn.setNamespace("prefix", "http://whatever/namespace/");
+        }
         sail.shutDown();
-        sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", false, 0, true, 0, null, null);
+        sail = new HBaseSail(hconn, "whatevertable", false, 0, true, 0, null, null);
         sail.initialize();
-        assertTrue(sail.getNamespaces().hasNext());
-        sail.removeNamespace("prefix");
+		try (SailConnection conn = sail.getConnection()) {
+	        assertTrue(conn.getNamespaces().hasNext());
+	        conn.removeNamespace("prefix");
+        }
         sail.shutDown();
-        sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", false, 0, true, 0, null, null);
+        sail = new HBaseSail(hconn, "whatevertable", false, 0, true, 0, null, null);
         sail.initialize();
-        assertFalse(sail.getNamespaces().hasNext());
-        sail.setNamespace("prefix", "http://whatever/namespace/");
-        sail.setNamespace("prefix", "http://whatever/namespace2/");
+		try (SailConnection conn = sail.getConnection()) {
+	        assertFalse(conn.getNamespaces().hasNext());
+	        conn.setNamespace("prefix", "http://whatever/namespace/");
+	        conn.setNamespace("prefix", "http://whatever/namespace2/");
+        }
         sail.shutDown();
-        sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", false, 0, true, 0, null, null);
+        sail = new HBaseSail(hconn, "whatevertable", false, 0, true, 0, null, null);
         sail.initialize();
-        assertEquals("http://whatever/namespace2/", sail.getNamespace("prefix"));
-        sail.clearNamespaces();
+		try (SailConnection conn = sail.getConnection()) {
+        	assertEquals("http://whatever/namespace2/", conn.getNamespace("prefix"));
+        	conn.clearNamespaces();
+        }
         sail.shutDown();
-        sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", false, 0, true, 0, null, null);
+        sail = new HBaseSail(hconn, "whatevertable", false, 0, true, 0, null, null);
         sail.initialize();
-        assertFalse(sail.getNamespaces().hasNext());
+		try (SailConnection conn = sail.getConnection()) {
+        	assertFalse(conn.getNamespaces().hasNext());
+        }
         sail.shutDown();
     }
 
@@ -226,25 +298,27 @@ public class HBaseSailTest {
         Value obj = vf.createLiteral("whatever");
         IRI context = vf.createIRI("http://whatever/context/");
         CloseableIteration<? extends Statement, SailException> iter;
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertableClear", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertableClear", true, 0, true, 0, null, null);
         sail.initialize();
-        sail.addStatement(subj, pred, obj, context);
-        sail.addStatement(subj, pred, obj);
-        sail.commit();
-        iter = sail.getStatements(subj, pred, obj, true);
-        assertTrue(iter.hasNext());
-        iter.close();
-        sail.clear(context);
-        iter = sail.getStatements(subj, pred, obj, true);
-        assertTrue(iter.hasNext());
-        iter.close();
-        iter = sail.getStatements(subj, pred, obj, true, context);
-        assertFalse(iter.hasNext());
-        iter.close();
-        sail.clear();
-        iter = sail.getStatements(subj, pred, obj, true);
-        assertFalse(iter.hasNext());
-        iter.close();
+		try (SailConnection conn = sail.getConnection()) {
+	        conn.addStatement(subj, pred, obj, context);
+	        conn.addStatement(subj, pred, obj);
+	        conn.commit();
+	        iter = conn.getStatements(subj, pred, obj, true);
+	        assertTrue(iter.hasNext());
+	        iter.close();
+	        conn.clear(context);
+	        iter = conn.getStatements(subj, pred, obj, true);
+	        assertTrue(iter.hasNext());
+	        iter.close();
+	        iter = conn.getStatements(subj, pred, obj, true, context);
+	        assertFalse(iter.hasNext());
+	        iter.close();
+	        conn.clear();
+	        iter = conn.getStatements(subj, pred, obj, true);
+	        assertFalse(iter.hasNext());
+	        iter.close();
+        }
     }
 
     @Test
@@ -253,90 +327,158 @@ public class HBaseSailTest {
         Resource subj = vf.createIRI("http://whatever/subj/");
         IRI pred = vf.createIRI("http://whatever/pred/");
         Value obj = vf.createLiteral("whatever");
-        CloseableIteration<? extends Statement, SailException> iter;
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
         SailRepository rep = new SailRepository(sail);
         rep.initialize();
-        sail.addStatement(subj, pred, obj);
-        sail.commit();
-        TupleQuery q = rep.getConnection().prepareTupleQuery(QueryLanguage.SPARQL, "select ?s ?p ?o where {<http://whatever/subj/> <http://whatever/pred/> \"whatever\"}");
-        TupleQueryResult res = q.evaluate();
-        assertTrue(res.hasNext());
+		try (RepositoryConnection conn = rep.getConnection()) {
+			conn.add(subj, pred, obj);
+			conn.commit();
+		}
+		try (RepositoryConnection conn = rep.getConnection()) {
+			TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+					"select ?s ?p ?o where {<http://whatever/subj/> <http://whatever/pred/> \"whatever\"}");
+			try (TupleQueryResult res = q.evaluate()) {
+				assertTrue(res.hasNext());
+			}
+		}
         rep.shutDown();
     }
 
     @Test
+	public void testEvaluateConstruct() throws Exception {
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		Resource subj = vf.createIRI("http://whatever/subj/");
+		IRI pred = vf.createIRI("http://whatever/pred/");
+		Value obj = vf.createLiteral("whatever");
+		HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
+		SailRepository rep = new SailRepository(sail);
+		rep.initialize();
+		try (RepositoryConnection conn = rep.getConnection()) {
+			conn.add(subj, pred, obj);
+			conn.commit();
+		}
+		try (RepositoryConnection conn = rep.getConnection()) {
+			GraphQuery q = conn.prepareGraphQuery(QueryLanguage.SPARQL, "construct {?s ?p ?o} where {?s ?p ?o}");
+			try (GraphQueryResult res = q.evaluate()) {
+				assertTrue(res.hasNext());
+			}
+		}
+		rep.shutDown();
+	}
+
+	@Test
     public void testEvaluateWithContext() throws Exception {
         ValueFactory vf = SimpleValueFactory.getInstance();
         Resource subj = vf.createIRI("http://whatever/subj/");
         IRI pred = vf.createIRI("http://whatever/pred/");
         Value obj = vf.createLiteral("whatever");
         IRI context = vf.createIRI("http://whatever/context/");
-        CloseableIteration<? extends Statement, SailException> iter;
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
         SailRepository rep = new SailRepository(sail);
         rep.initialize();
-        sail.addStatement(subj, pred, obj, context);
-        sail.commit();
-        TupleQuery q = rep.getConnection().prepareTupleQuery(QueryLanguage.SPARQL, "select ?s ?p ?o from named <http://whatever/context/> where {<http://whatever/subj/> <http://whatever/pred/> \"whatever\"}");
-        TupleQueryResult res = q.evaluate();
-        assertFalse(res.hasNext());
+		try (RepositoryConnection conn = rep.getConnection()) {
+			conn.add(subj, pred, obj, context);
+			conn.commit();
+		}
+		try (RepositoryConnection conn = rep.getConnection()) {
+			TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+					"select ?s ?p ?o from named <http://whatever/context/> where {<http://whatever/subj/> <http://whatever/pred/> \"whatever\"}");
+			try (TupleQueryResult res = q.evaluate()) {
+				assertFalse(res.hasNext());
+			}
+		}
         rep.shutDown();
     }
 
     @Test
-    public void testEvaluateService() throws Exception {
+	public void testEvaluateSelectService() throws Exception {
         ValueFactory vf = SimpleValueFactory.getInstance();
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whateverservice", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whateverservice", true, 0, true, 0, null, null);
         SailRepository rep = new SailRepository(sail);
         rep.initialize();
         Random r = new Random(333);
         IRI pred = vf.createIRI("http://whatever/pred");
         IRI meta = vf.createIRI("http://whatever/meta");
-        for (int i = 0; i < 1000; i++) {
-            IRI subj = vf.createIRI("http://whatever/subj#" + r.nextLong());
-            IRI graph = vf.createIRI("http://whatever/grp#" + r.nextLong());
-            sail.addStatement(subj, pred, graph, meta);
-            for (int j = 0; j < 10; j++) {
-                IRI s = vf.createIRI("http://whatever/s#" + r.nextLong());
-                IRI p = vf.createIRI("http://whatever/p#" + r.nextLong());
-                IRI o = vf.createIRI("http://whatever/o#" + r.nextLong());
-                sail.addStatement(s, p, o, graph);
-            }
-        }
-        sail.commit();
+		try (RepositoryConnection conn = rep.getConnection()) {
+			for (int i = 0; i < 1000; i++) {
+				IRI subj = vf.createIRI("http://whatever/subj#" + r.nextLong());
+				IRI graph = vf.createIRI("http://whatever/grp#" + r.nextLong());
+				conn.add(subj, pred, graph, meta);
+				for (int j = 0; j < 10; j++) {
+					IRI s = vf.createIRI("http://whatever/s#" + r.nextLong());
+					IRI p = vf.createIRI("http://whatever/p#" + r.nextLong());
+					IRI o = vf.createIRI("http://whatever/o#" + r.nextLong());
+					conn.add(s, p, o, graph);
+				}
+			}
+			conn.commit();
+		}
         rep.shutDown();
 
-        sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whateverparent", true, 0, true, 0, null, null);
+        sail = new HBaseSail(hconn, "whateverparent", true, 0, true, 0, null, null);
         rep = new SailRepository(sail);
         rep.initialize();
-        TupleQuery q = rep.getConnection().prepareTupleQuery(QueryLanguage.SPARQL,
-            "select * where {"
-            + "  SERVICE <" + HALYARD.NAMESPACE + "whateverservice> {"
-            + "    graph <http://whatever/meta> {"
-            + "      ?subj <http://whatever/pred> ?graph"
-            + "    }"
-            + "    graph ?graph {"
-            + "      ?s ?p ?o"
-            + "    }"
-            + "  }"
-            + "}");
-        TupleQueryResult res = q.evaluate();
-        int count = 0;
-        while (res.hasNext()) {
-            count++;
-            res.next();
-        }
+		try (RepositoryConnection conn = rep.getConnection()) {
+			TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+					"select * where {" + "  SERVICE <" + HALYARD.NAMESPACE + "whateverservice> {"
+							+ "    graph <http://whatever/meta> {" + "      ?subj <http://whatever/pred> ?graph"
+							+ "    }" + "    graph ?graph {" + "      ?s ?p ?o" + "    }" + "  }" + "}");
+			int count = 0;
+			try (TupleQueryResult res = q.evaluate()) {
+				while (res.hasNext()) {
+					count++;
+					res.next();
+				}
+			}
+			assertEquals(10000, count);
+		}
         rep.shutDown();
-        assertEquals(10000, count);
     }
+
+	@Test
+	public void testEvaluateAskService() throws Exception {
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		HBaseSail sail = new HBaseSail(hconn, "whateverservice", true, 0, true, 0, null, null);
+		SailRepository rep = new SailRepository(sail);
+		rep.initialize();
+		Random r = new Random(333);
+		IRI pred = vf.createIRI("http://whatever/pred");
+		IRI meta = vf.createIRI("http://whatever/meta");
+		try (RepositoryConnection conn = rep.getConnection()) {
+			for (int i = 0; i < 1000; i++) {
+				IRI subj = vf.createIRI("http://whatever/subj#" + r.nextLong());
+				IRI graph = vf.createIRI("http://whatever/grp#" + r.nextLong());
+				conn.add(subj, pred, graph, meta);
+				for (int j = 0; j < 10; j++) {
+					IRI s = vf.createIRI("http://whatever/s#" + r.nextLong());
+					IRI p = vf.createIRI("http://whatever/p#" + r.nextLong());
+					IRI o = vf.createIRI("http://whatever/o#" + r.nextLong());
+					conn.add(s, p, o, graph);
+				}
+			}
+			conn.commit();
+		}
+		rep.shutDown();
+
+		sail = new HBaseSail(hconn, "whateverparent", true, 0, true, 0, null, null);
+		rep = new SailRepository(sail);
+		rep.initialize();
+		try (RepositoryConnection conn = rep.getConnection()) {
+			BooleanQuery q = conn.prepareBooleanQuery(QueryLanguage.SPARQL, "ask where {" + "  SERVICE <" + HALYARD.NAMESPACE + "whateverservice> {" + "    graph <http://whatever/meta> {" + "      ?subj <http://whatever/pred> ?graph"
+					+ "    }" + "    graph ?graph {" + "      ?s ?p ?o" + "    }" + "  }" + "}");
+			assertTrue(q.evaluate());
+		}
+		rep.shutDown();
+	}
 
     @Test(expected = UnsupportedOperationException.class)
     public void testStatementsIteratorRemove1() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
         try {
             sail.initialize();
-            sail.getStatements(null, null, null, true).remove();
+			try (SailConnection conn = sail.getConnection()) {
+				conn.getStatements(null, null, null, true).remove();
+			}
         } finally {
             sail.shutDown();
         }
@@ -344,11 +486,14 @@ public class HBaseSailTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testStatementsIteratorRemove2() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
         try {
             sail.initialize();
             ValueFactory vf = SimpleValueFactory.getInstance();
-            sail.getStatements(vf.createIRI("http://whatever/subj/"), vf.createIRI("http://whatever/pred/"), vf.createIRI("http://whatever/obj/"), true).remove();
+			try (SailConnection conn = sail.getConnection()) {
+				conn.getStatements(vf.createIRI("http://whatever/subj/"), vf.createIRI("http://whatever/pred/"),
+						vf.createIRI("http://whatever/obj/"), true).remove();
+			}
         } finally {
             sail.shutDown();
         }
@@ -356,25 +501,36 @@ public class HBaseSailTest {
 
     @Test
     public void testEmptyMethodsThatShouldDoNothing() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 0, null, null);
-        sail.setDataDir(null);
-        sail.prepare();
-        sail.begin();
-        sail.flush();
-        sail.startUpdate(null);
-        sail.endUpdate(null);
-        sail.close();
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 0, null, null);
+		try {
+			sail.setDataDir(null);
+			sail.initialize();
+			try (SailConnection conn = sail.getConnection()) {
+				conn.prepare();
+				conn.begin();
+				conn.flush();
+				assertFalse(conn.pendingRemovals());
+				conn.startUpdate(null);
+				conn.endUpdate(null);
+			}
+		} finally {
+			sail.shutDown();
+		}
     }
 
     @Test(expected = SailException.class)
     public void testTimeoutGetStatements() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whatevertable", true, 0, true, 1, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whatevertable", true, 0, true, 1, null, null);
         sail.initialize();
         try {
-            sail.commit();
-            CloseableIteration<? extends Statement, SailException> it = sail.getStatements(null, null, null, true);
-            Thread.sleep(2000);
-            it.hasNext();
+			try (SailConnection conn = sail.getConnection()) {
+				conn.commit();
+				try (CloseableIteration<? extends Statement, SailException> it = conn.getStatements(null, null, null,
+						true)) {
+					Thread.sleep(2000);
+					it.hasNext();
+				}
+			}
         } finally {
             sail.shutDown();
         }
@@ -382,7 +538,7 @@ public class HBaseSailTest {
 
     @Test
     public void testCardinalityCalculator() throws Exception {
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "cardinalitytable", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "cardinalitytable", true, 0, true, 0, null, null);
         sail.initialize();
         SimpleValueFactory f = SimpleValueFactory.getInstance();
         TupleExpr q1 = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL, "select * where {?s a ?o}", "http://whatever/").getTupleExpr();
@@ -393,11 +549,13 @@ public class HBaseSailTest {
         assertEquals(100.0, sail.statistics.getCardinality(q2), 0.01);
         assertEquals(100.0, sail.statistics.getCardinality(q3), 0.01);
         assertEquals(1.0, sail.statistics.getCardinality(q4), 0.01);
-        sail.addStatement(HALYARD.STATS_ROOT_NODE, VOID.TRIPLES, f.createLiteral(10000l), HALYARD.STATS_GRAPH_CONTEXT);
-        sail.addStatement(f.createIRI(HALYARD.STATS_ROOT_NODE.stringValue() + "_property_" + HalyardTableUtils.encode(HalyardTableUtils.hashKey(RDF.TYPE))), VOID.TRIPLES, f.createLiteral(5000l), HALYARD.STATS_GRAPH_CONTEXT);
-        sail.addStatement(f.createIRI("http://whatevercontext"), VOID.TRIPLES, f.createLiteral(10000l), HALYARD.STATS_GRAPH_CONTEXT);
-        sail.addStatement(f.createIRI("http://whatevercontext_property_" + HalyardTableUtils.encode(HalyardTableUtils.hashKey(RDF.TYPE))), VOID.TRIPLES, f.createLiteral(20l), HALYARD.STATS_GRAPH_CONTEXT);
-        sail.commit();
+		try (SailConnection conn = sail.getConnection()) {
+	        conn.addStatement(HALYARD.STATS_ROOT_NODE, VOID.TRIPLES, f.createLiteral(10000l), HALYARD.STATS_GRAPH_CONTEXT);
+	        conn.addStatement(f.createIRI(HALYARD.STATS_ROOT_NODE.stringValue() + "_property_" + HalyardTableUtils.encode(HalyardTableUtils.hashKey(RDF.TYPE))), VOID.TRIPLES, f.createLiteral(5000l), HALYARD.STATS_GRAPH_CONTEXT);
+	        conn.addStatement(f.createIRI("http://whatevercontext"), VOID.TRIPLES, f.createLiteral(10000l), HALYARD.STATS_GRAPH_CONTEXT);
+	        conn.addStatement(f.createIRI("http://whatevercontext_property_" + HalyardTableUtils.encode(HalyardTableUtils.hashKey(RDF.TYPE))), VOID.TRIPLES, f.createLiteral(20l), HALYARD.STATS_GRAPH_CONTEXT);
+	        conn.commit();
+		}
         assertEquals(5000.0, sail.statistics.getCardinality(q1), 0.01);
         assertEquals(20.0, sail.statistics.getCardinality(q2), 0.01);
         assertEquals(100.0, sail.statistics.getCardinality(q3), 0.01);
@@ -406,24 +564,41 @@ public class HBaseSailTest {
     }
 
     @Test
-    public void testEvaluateServiceWithBindings() throws Exception {
+	public void testEvaluateSelectServiceWithBindings() throws Exception {
         ValueFactory vf = SimpleValueFactory.getInstance();
-        HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "whateverservice2", true, 0, true, 0, null, null);
+        HBaseSail sail = new HBaseSail(hconn, "whateverservice2", true, 0, true, 0, null, null);
         SailRepository rep = new SailRepository(sail);
         rep.initialize();
-        Random r = new Random(333);
-        sail.addStatement(vf.createIRI("http://whatever/subj"), vf.createIRI("http://whatever/pred"), vf.createIRI("http://whatever/obj"));
-        sail.commit();
-        TupleQuery q = rep.getConnection().prepareTupleQuery(QueryLanguage.SPARQL,
-            "select * where {"
-            + "  bind (\"a\" as ?a)\n"
-            + "  SERVICE <" + HALYARD.NAMESPACE + "whateverservice2> {"
-            + "    ?s ?p ?o"
-            + "  }"
-            + "}");
-        TupleQueryResult res = q.evaluate();
-        assertTrue(res.hasNext());
-        assertNotNull(res.next().getValue("a"));
+		try (RepositoryConnection conn = rep.getConnection()) {
+			conn.add(vf.createIRI("http://whatever/subj"), vf.createIRI("http://whatever/pred"),
+					vf.createIRI("http://whatever/obj"));
+			conn.commit();
+		}
+		try (RepositoryConnection conn = rep.getConnection()) {
+			TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL, "select * where {" + "  bind (\"a\" as ?a)\n"
+					+ "  SERVICE <" + HALYARD.NAMESPACE + "whateverservice2> {" + "    ?s ?p ?o" + "  }" + "}");
+			try (TupleQueryResult res = q.evaluate()) {
+				assertTrue(res.hasNext());
+				assertNotNull(res.next().getValue("a"));
+			}
+		}
         rep.shutDown();
     }
+
+	@Test
+	public void testEvaluateAskServiceWithBindings() throws Exception {
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		HBaseSail sail = new HBaseSail(hconn, "whateverservice2", true, 0, true, 0, null, null);
+		SailRepository rep = new SailRepository(sail);
+		rep.initialize();
+		try (RepositoryConnection conn = rep.getConnection()) {
+			conn.add(vf.createIRI("http://whatever/subj"), vf.createIRI("http://whatever/pred"), vf.createIRI("http://whatever/obj"));
+			conn.commit();
+		}
+		try (RepositoryConnection conn = rep.getConnection()) {
+			BooleanQuery q = conn.prepareBooleanQuery(QueryLanguage.SPARQL, "ask where {" + "  bind (\"a\" as ?a)\n" + "  SERVICE <" + HALYARD.NAMESPACE + "whateverservice2> {" + "    ?s ?p ?o" + "  }" + "}");
+			assertTrue(q.evaluate());
+		}
+		rep.shutDown();
+	}
 }

--- a/sail/src/test/java/com/msd/gin/halyard/sail/SES2154SubselectOptionalTest.java
+++ b/sail/src/test/java/com/msd/gin/halyard/sail/SES2154SubselectOptionalTest.java
@@ -16,16 +16,19 @@
  */
 package com.msd.gin.halyard.sail;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
 
 /**
  *
@@ -40,12 +43,16 @@ public class SES2154SubselectOptionalTest {
         rep.initialize();
         SimpleValueFactory vf = SimpleValueFactory.getInstance();
         IRI person = vf.createIRI("http://schema.org/Person");
-        for (char c = 'a'; c < 'k'; c++) {
-            sail.addStatement(vf.createIRI("http://example.com/" + c), RDF.TYPE, person);
-        }
-        sail.commit();
-        TupleQueryResult res = rep.getConnection().prepareTupleQuery(QueryLanguage.SPARQL, "PREFIX : <http://example.com/>\n" + "PREFIX schema: <http://schema.org/>\n" + "\n" + "SELECT (COUNT(*) AS ?count)\n" + "WHERE {\n" + "  {\n" + "    SELECT ?person\n" + "    WHERE {\n" + "      ?person a schema:Person .\n" + "    }\n" + "    LIMIT 5\n" + "  }\n" + "  OPTIONAL {\n" + "    [] :nonexistent [] .\n" + "  }\n" + "}").evaluate();
-        assertEquals(5, ((Literal) res.next().getBinding("count").getValue()).intValue());
+		try (RepositoryConnection conn = rep.getConnection()) {
+			for (char c = 'a'; c < 'k'; c++) {
+				conn.add(vf.createIRI("http://example.com/" + c), RDF.TYPE, person);
+			}
+			conn.commit();
+			try (TupleQueryResult res = rep.getConnection().prepareTupleQuery(QueryLanguage.SPARQL, "PREFIX : <http://example.com/>\n" + "PREFIX schema: <http://schema.org/>\n" + "\n" + "SELECT (COUNT(*) AS ?count)\n" + "WHERE {\n"
+					+ "  {\n" + "    SELECT ?person\n" + "    WHERE {\n" + "      ?person a schema:Person .\n" + "    }\n" + "    LIMIT 5\n" + "  }\n" + "  OPTIONAL {\n" + "    [] :nonexistent [] .\n" + "  }\n" + "}").evaluate()) {
+				assertEquals(5, ((Literal) res.next().getBinding("count").getValue()).intValue());
+			}
+		}
         rep.shutDown();
     }
 

--- a/strategy/src/test/java/com/msd/gin/halyard/strategy/ArbitraryLengthPathTest.java
+++ b/strategy/src/test/java/com/msd/gin/halyard/strategy/ArbitraryLengthPathTest.java
@@ -16,15 +16,16 @@
  */
 package com.msd.gin.halyard.strategy;
 
+import static junit.framework.TestCase.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collection;
-import static junit.framework.TestCase.assertTrue;
+
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,9 +67,9 @@ public class ArbitraryLengthPathTest {
     public void testN() throws Exception {
         ValueFactory vf = con.getValueFactory();
         for (int i = 0; i < n; i++) {
-            con.add(vf.createURI("urn:test:root"), vf.createURI("urn:test:hasChild"), vf.createURI("urn:test:node" + i));
+			con.add(vf.createIRI("urn:test:root"), vf.createIRI("urn:test:hasChild"), vf.createIRI("urn:test:node" + i));
         }
-        con.add(vf.createURI("urn:test:root"), vf.createURI("urn:test:hasChild"), vf.createURI("urn:test:node-end"));
+		con.add(vf.createIRI("urn:test:root"), vf.createIRI("urn:test:hasChild"), vf.createIRI("urn:test:node-end"));
         String sparql = "ASK { <urn:test:root> <urn:test:hasChild>* <urn:test:node-end> }";
         assertTrue(con.prepareBooleanQuery(QueryLanguage.SPARQL, sparql).evaluate());
     }

--- a/strategy/src/test/java/com/msd/gin/halyard/strategy/HalyardStrategyExtendedTest.java
+++ b/strategy/src/test/java/com/msd/gin/halyard/strategy/HalyardStrategyExtendedTest.java
@@ -16,7 +16,10 @@
  */
 package com.msd.gin.halyard.strategy;
 
-import static junit.framework.TestCase.*;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -25,13 +28,10 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQueryResult;
-import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-
 import org.junit.After;
-import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/tools/src/main/java/com/msd/gin/halyard/tools/HalyardEndpoint.java
+++ b/tools/src/main/java/com/msd/gin/halyard/tools/HalyardEndpoint.java
@@ -109,8 +109,6 @@ public final class HalyardEndpoint extends AbstractHalyardTool {
                     new HBaseSail(getConf(), table, false, 0, true, timeout, elasticIndexURL, null));
             rep.initialize();
             try {
-                SailRepositoryConnection connection = rep.getConnection();
-                connection.begin();
                 Properties storedQueries = new Properties();
                 if (cmd.hasOption('q')) {
                     try (FileInputStream in = new FileInputStream(cmd.getOptionValue('q'))) {
@@ -123,7 +121,7 @@ public final class HalyardEndpoint extends AbstractHalyardTool {
                         writerConfig.load(in);
                     }
                 }
-                HttpSparqlHandler handler = new HttpSparqlHandler(connection, storedQueries, writerConfig, verbose);
+                HttpSparqlHandler handler = new HttpSparqlHandler(rep, storedQueries, writerConfig, verbose);
                 SimpleHttpServer server = new SimpleHttpServer(port, CONTEXT, handler);
                 server.start();
                 try {

--- a/tools/src/main/java/com/msd/gin/halyard/tools/HalyardExport.java
+++ b/tools/src/main/java/com/msd/gin/halyard/tools/HalyardExport.java
@@ -66,6 +66,7 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -518,15 +519,17 @@ public final class HalyardExport extends AbstractHalyardTool {
                 try {
                     writer.initTimer();
                     log.logStatus("Query execution started");
-                    Query q = rep.getConnection().prepareQuery(QueryLanguage.SPARQL, query);
-                    if (q instanceof TupleQuery) {
-                        writer.writeTupleQueryResult(((TupleQuery)q).evaluate());
-                    } else if (q instanceof GraphQuery) {
-                        writer.writeGraphQueryResult(((GraphQuery)q).evaluate());
-                    } else {
-                        throw new ExportException("Only SPARQL Tuple and Graph query types are supported.");
+                    try(RepositoryConnection conn = rep.getConnection()) {
+	                    Query q = conn.prepareQuery(QueryLanguage.SPARQL, query);
+	                    if (q instanceof TupleQuery) {
+	                        writer.writeTupleQueryResult(((TupleQuery)q).evaluate());
+	                    } else if (q instanceof GraphQuery) {
+	                        writer.writeGraphQueryResult(((GraphQuery)q).evaluate());
+	                    } else {
+	                        throw new ExportException("Only SPARQL Tuple and Graph query types are supported.");
+	                    }
+	                    log.logStatus("Export finished");
                     }
-                    log.logStatus("Export finished");
                 } finally {
                     rep.shutDown();
                 }

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardBulkDeleteTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardBulkDeleteTest.java
@@ -16,9 +16,10 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HBaseSail;
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
+
 import org.apache.commons.cli.MissingOptionException;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.hadoop.conf.Configuration;
@@ -27,10 +28,13 @@ import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.junit.Assert;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
 
 /**
  *
@@ -46,12 +50,14 @@ public class HalyardBulkDeleteTest {
         Configuration conf = HBaseServerTestInstance.getInstanceConfig();
         HBaseSail sail = new HBaseSail(conf, TABLE, true, -1, true, 0, null, null);
         sail.initialize();
-        for (int i=0; i<5; i++) {
-            for (int j=0; j<5; j++) {
-                sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred"), vf.createIRI("http://whatever/obj" + j), i == 0 ? null: vf.createIRI("http://whatever/ctx" + i));
-            }
+		try (SailConnection conn = sail.getConnection()) {
+			for (int i = 0; i < 5; i++) {
+				for (int j = 0; j < 5; j++) {
+					conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred"), vf.createIRI("http://whatever/obj" + j), i == 0 ? null : vf.createIRI("http://whatever/ctx" + i));
+				}
+			}
+			conn.commit();
         }
-        sail.commit();
         sail.shutDown();
         File htableDir = File.createTempFile("test_htable", "");
         htableDir.delete();
@@ -79,15 +85,17 @@ public class HalyardBulkDeleteTest {
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), TABLE, false, 0, true, 0, null, null);
         sail.initialize();
         try {
-            int count;
-            try (CloseableIteration<? extends Statement, SailException> iter = sail.getStatements(null, null, null, true)) {
-                count = 0;
-                while (iter.hasNext()) {
-                    iter.next();
-                    count++;
-                }
-            }
-            Assert.assertEquals(expected, count);
+			try (SailConnection conn = sail.getConnection()) {
+				int count;
+				try (CloseableIteration<? extends Statement, SailException> iter = conn.getStatements(null, null, null, true)) {
+					count = 0;
+					while (iter.hasNext()) {
+						iter.next();
+						count++;
+					}
+				}
+				Assert.assertEquals(expected, count);
+			}
         } finally {
             sail.shutDown();
         }

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardBulkExportTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardBulkExportTest.java
@@ -16,17 +16,22 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HBaseSail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.PrintStream;
+
 import org.apache.commons.cli.MissingOptionException;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.hadoop.util.ToolRunner;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import static org.junit.Assert.*;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.junit.Test;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
 
 /**
  *
@@ -39,11 +44,12 @@ public class HalyardBulkExportTest {
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "bulkExportTable", true, 0, true, 0, null, null);
         sail.initialize();
         ValueFactory vf = SimpleValueFactory.getInstance();
-        for (int i = 0; i < 1000; i++) {
-            sail.addStatement(vf.createIRI("http://whatever/NTsubj"), vf.createIRI("http://whatever/NTpred" + i),  vf.createLiteral("whatever NT value " + i));
-        }
-        sail.commit();
-        sail.close();
+		try (SailConnection conn = sail.getConnection()) {
+			for (int i = 0; i < 1000; i++) {
+				conn.addStatement(vf.createIRI("http://whatever/NTsubj"), vf.createIRI("http://whatever/NTpred" + i), vf.createLiteral("whatever NT value " + i));
+			}
+			conn.commit();
+		}
 
         File root = File.createTempFile("test_bulkExport", "");
         root.delete();
@@ -76,11 +82,12 @@ public class HalyardBulkExportTest {
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "bulkExportTable2", true, 0, true, 0, null, null);
         sail.initialize();
         ValueFactory vf = SimpleValueFactory.getInstance();
-        for (int i = 0; i < 1000; i++) {
-            sail.addStatement(vf.createIRI("http://whatever/NTsubj"), vf.createIRI("http://whatever/NTpred" + i),  vf.createLiteral("whatever NT value " + i));
-        }
-        sail.commit();
-        sail.close();
+		try (SailConnection conn = sail.getConnection()) {
+			for (int i = 0; i < 1000; i++) {
+				conn.addStatement(vf.createIRI("http://whatever/NTsubj"), vf.createIRI("http://whatever/NTpred" + i), vf.createLiteral("whatever NT value " + i));
+			}
+			conn.commit();
+		}
 
         File root = File.createTempFile("test_parallelBulkExport", "");
         root.delete();

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardBulkLoadTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardBulkLoadTest.java
@@ -16,12 +16,15 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HBaseSail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.zip.GZIPOutputStream;
+
 import org.apache.commons.cli.MissingOptionException;
 import org.apache.hadoop.util.ToolRunner;
 import org.eclipse.rdf4j.model.Literal;
@@ -30,8 +33,11 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import static org.junit.Assert.*;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.junit.Test;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
 
 /**
  *
@@ -161,7 +167,9 @@ public class HalyardBulkLoadTest {
 
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "bulkLoadTable2", false, 0, true, 30, null, null);
         sail.initialize();
-        assertEquals(3, sail.size());
+		try (SailConnection conn = sail.getConnection()) {
+			assertEquals(3, conn.size());
+		}
         sail.shutDown();
     }
 

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardBulkUpdateTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardBulkUpdateTest.java
@@ -16,14 +16,15 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HBaseSail;
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.PrintStream;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Random;
 import java.util.TreeMap;
+
 import org.apache.commons.cli.MissingOptionException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ToolRunner;
@@ -34,10 +35,13 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.junit.Assert;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
 
 /**
  *
@@ -53,12 +57,14 @@ public class HalyardBulkUpdateTest {
         Configuration conf = HBaseServerTestInstance.getInstanceConfig();
         HBaseSail sail = new HBaseSail(conf, TABLE, true, -1, true, 0, null, null);
         sail.initialize();
-        for (int i=0; i<5; i++) {
-            for (int j=0; j<5; j++) {
-                sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred"), vf.createIRI("http://whatever/obj" + j));
-            }
-        }
-        sail.commit();
+		try (SailConnection conn = sail.getConnection()) {
+			for (int i = 0; i < 5; i++) {
+				for (int j = 0; j < 5; j++) {
+					conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred"), vf.createIRI("http://whatever/obj" + j));
+				}
+			}
+			conn.commit();
+		}
         sail.shutDown();
         File queries = File.createTempFile("test_update_queries", "");
         queries.delete();
@@ -84,16 +90,20 @@ public class HalyardBulkUpdateTest {
         sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), TABLE, false, 0, true, 0, null, null);
         sail.initialize();
         try {
-            int count;
-            try (CloseableIteration<? extends Statement, SailException> iter = sail.getStatements(null, null, null, true)) {
-                count = 0;
-                while (iter.hasNext()) {
-                    iter.next();
-                    count++;
-                }
-            }
-            Assert.assertEquals(50, count);
-            Assert.assertFalse(sail.getStatements(null, SimpleValueFactory.getInstance().createIRI("http://whatever/pred"), null, true).hasNext());
+			try (SailConnection conn = sail.getConnection()) {
+				int count;
+				try (CloseableIteration<? extends Statement, SailException> iter = conn.getStatements(null, null, null, true)) {
+					count = 0;
+					while (iter.hasNext()) {
+						iter.next();
+						count++;
+					}
+				}
+				Assert.assertEquals(50, count);
+				try (CloseableIteration<? extends Statement, SailException> iter = conn.getStatements(null, SimpleValueFactory.getInstance().createIRI("http://whatever/pred"), null, true)) {
+					Assert.assertFalse(iter.hasNext());
+				}
+			}
         } finally {
             sail.shutDown();
         }
@@ -150,23 +160,25 @@ public class HalyardBulkUpdateTest {
         IRI deleteGraph = SimpleValueFactory.getInstance().createIRI("http://whatever/deleteGraph");
         IRI insertGraph = SimpleValueFactory.getInstance().createIRI("http://whatever/insertGraph");
         IRI context = SimpleValueFactory.getInstance().createIRI("http://whatever/context");
-        for (Change c : changes.values()) {
-            IRI chSubj = SimpleValueFactory.getInstance().createIRI("http://whatever/change#" + i);
-            IRI delGr = SimpleValueFactory.getInstance().createIRI("http://whatever/graph#" + i + "d");
-            IRI insGr = SimpleValueFactory.getInstance().createIRI("http://whatever/graph#" + i + "i");
-            sail.addStatement(chSubj, timstamp, SimpleValueFactory.getInstance().createLiteral(c.timestamp));
-            sail.addStatement(chSubj, context, targetGraph);
-            sail.addStatement(chSubj, deleteGraph, delGr);
-            sail.addStatement(chSubj, insertGraph, insGr);
-            for (Statement s : c.deletes) {
-                sail.addStatement(s.getSubject(), s.getPredicate(), s.getObject(), delGr);
-            }
-            for (Statement s : c.inserts) {
-                sail.addStatement(s.getSubject(), s.getPredicate(), s.getObject(), insGr);
-            }
-            i++;
-        }
-        sail.commit();
+		try (SailConnection conn = sail.getConnection()) {
+			for (Change c : changes.values()) {
+				IRI chSubj = SimpleValueFactory.getInstance().createIRI("http://whatever/change#" + i);
+				IRI delGr = SimpleValueFactory.getInstance().createIRI("http://whatever/graph#" + i + "d");
+				IRI insGr = SimpleValueFactory.getInstance().createIRI("http://whatever/graph#" + i + "i");
+				conn.addStatement(chSubj, timstamp, SimpleValueFactory.getInstance().createLiteral(c.timestamp));
+				conn.addStatement(chSubj, context, targetGraph);
+				conn.addStatement(chSubj, deleteGraph, delGr);
+				conn.addStatement(chSubj, insertGraph, insGr);
+				for (Statement s : c.deletes) {
+					conn.addStatement(s.getSubject(), s.getPredicate(), s.getObject(), delGr);
+				}
+				for (Statement s : c.inserts) {
+					conn.addStatement(s.getSubject(), s.getPredicate(), s.getObject(), insGr);
+				}
+				i++;
+			}
+			conn.commit();
+		}
         sail.shutDown();
 
         //prepare the update queries
@@ -231,11 +243,13 @@ public class HalyardBulkUpdateTest {
         sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "timebulkupdatetesttable", false, 0, true, 0, null, null);
         sail.initialize();
         try {
-            try (CloseableIteration<? extends Statement, SailException> iter = sail.getStatements(null, null, null, true, targetGraph)) {
-                while (iter.hasNext()) {
-                    resultModel.add(iter.next());
-                }
-            }
+			try (SailConnection conn = sail.getConnection()) {
+				try (CloseableIteration<? extends Statement, SailException> iter = conn.getStatements(null, null, null, true, targetGraph)) {
+					while (iter.hasNext()) {
+						resultModel.add(iter.next());
+					}
+				}
+			}
         } finally {
             sail.shutDown();
         }

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardEndpointTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardEndpointTest.java
@@ -16,26 +16,28 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HBaseSail;
-import org.apache.commons.cli.MissingOptionException;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.util.ToolRunner;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.util.ToolRunner;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
 
 /**
  * Class for testing the tool HalyardEndpoint.
@@ -64,18 +66,16 @@ public class HalyardEndpointTest {
         ValueFactory vf = SimpleValueFactory.getInstance();
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), TABLE, true, 0, true, 0, null, null);
         sail.initialize();
-        for (int i = 0; i < 10; i++) {
-            for (int j = 0; j < 10; j++) {
-                for (int k = 0; k < 10; k++) {
-                    sail.addStatement(
-                            vf.createIRI("http://whatever/subj" + i),
-                            vf.createIRI("http://whatever/pred" + j),
-                            vf.createLiteral("whatever\n\"\\" + k)
-                    );
-                }
-            }
-        }
-        sail.commit();
+		try (SailConnection conn = sail.getConnection()) {
+			for (int i = 0; i < 10; i++) {
+				for (int j = 0; j < 10; j++) {
+					for (int k = 0; k < 10; k++) {
+						conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred" + j), vf.createLiteral("whatever\n\"\\" + k));
+					}
+				}
+			}
+			conn.commit();
+		}
         sail.shutDown();
     }
 

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardExportJDBCTypesTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardExportJDBCTypesTest.java
@@ -16,8 +16,9 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HBaseSail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -26,14 +27,18 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Date;
+
 import org.apache.hadoop.util.ToolRunner;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.Test;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.junit.BeforeClass;
-import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestName;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
 
 /**
  *
@@ -51,21 +56,23 @@ public class HalyardExportJDBCTypesTest {
         ValueFactory vf = SimpleValueFactory.getInstance();
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), TABLE, true, 0, true, 0, null, null);
         sail.initialize();
-        for (int i=1; i<10; i++) {
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/date"), vf.createLiteral(new Date(i, i, i)));
-            Date d = new Date(i, i, i, i, i, i);
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/time"), vf.createLiteral(d));
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/timestamp"), vf.createLiteral(new Date(d.getTime() + i))); // add millis
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/string"), vf.createLiteral("value" + i));
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/boolean"), vf.createLiteral(i < 5));
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/byte"), vf.createLiteral((byte)i));
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/double"), vf.createLiteral((double)i/100.0));
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/float"), vf.createLiteral((float)i/10.0));
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/int"), vf.createLiteral(i * 100));
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/long"), vf.createLiteral((long)i * 10000000000l));
-            sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/short"), vf.createLiteral((short)(i * 10)));
-        }
-        sail.commit();
+		try (SailConnection conn = sail.getConnection()) {
+			for (int i = 1; i < 10; i++) {
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/date"), vf.createLiteral(new Date(i, i, i)));
+				Date d = new Date(i, i, i, i, i, i);
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/time"), vf.createLiteral(d));
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/timestamp"), vf.createLiteral(new Date(d.getTime() + i))); // add millis
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/string"), vf.createLiteral("value" + i));
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/boolean"), vf.createLiteral(i < 5));
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/byte"), vf.createLiteral((byte) i));
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/double"), vf.createLiteral((double) i / 100.0));
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/float"), vf.createLiteral((float) i / 10.0));
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/int"), vf.createLiteral(i * 100));
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/long"), vf.createLiteral((long) i * 10000000000l));
+				conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/short"), vf.createLiteral((short) (i * 10)));
+			}
+			conn.commit();
+		}
         sail.shutDown();
     }
 

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardExportTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardExportTest.java
@@ -16,9 +16,9 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.tools.HalyardExport.ExportException;
-import com.msd.gin.halyard.sail.HBaseSail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -29,9 +29,8 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.commons.cli.MissingOptionException;
-import org.junit.Test;
-import org.junit.BeforeClass;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FileUtils;
@@ -46,10 +45,16 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.junit.AfterClass;
-import static org.junit.Assert.*;
+import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestName;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
+import com.msd.gin.halyard.tools.HalyardExport.ExportException;
 
 /**
  *
@@ -77,14 +82,16 @@ public class HalyardExportTest {
         ValueFactory vf = SimpleValueFactory.getInstance();
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), TABLE, true, 0, true, 0, null, null);
         sail.initialize();
-        for (int i=0; i<10; i++) {
-            for (int j=0; j<10; j++) {
-                for (int k=0; k<10; k++) {
-                    sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred" + j), vf.createLiteral("whatever\n\"\\" + k));
-                }
-            }
-        }
-        sail.commit();
+		try (SailConnection conn = sail.getConnection()) {
+			for (int i = 0; i < 10; i++) {
+				for (int j = 0; j < 10; j++) {
+					for (int k = 0; k < 10; k++) {
+						conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred" + j), vf.createLiteral("whatever\n\"\\" + k));
+					}
+				}
+			}
+			conn.commit();
+		}
         sail.shutDown();
     }
 

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardPreSplitTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardPreSplitTest.java
@@ -16,16 +16,20 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.common.HalyardTableUtils;
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+
 import org.apache.commons.cli.MissingOptionException;
-import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.util.ToolRunner;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.common.HalyardTableUtils;
 
 /**
  *
@@ -43,9 +47,11 @@ public class HalyardPreSplitTest {
 
         assertEquals(0, ToolRunner.run(HBaseServerTestInstance.getInstanceConfig(), new HalyardPreSplit(), new String[]{"-d", "1", "-l",  "0", "-s", file.toURI().toURL().toString(), "-t", "preSplitTable"}));
 
-        try (HTable t = HalyardTableUtils.getTable(HBaseServerTestInstance.getInstanceConfig(), "preSplitTable", false, 0)) {
-            assertEquals(17, t.getRegionLocator().getStartKeys().length);
+		Connection conn = HalyardTableUtils.getConnection(HBaseServerTestInstance.getInstanceConfig());
+		try (Table t = HalyardTableUtils.getTable(conn, "preSplitTable", false, 0)) {
+			assertEquals(17, conn.getRegionLocator(t.getName()).getStartKeys().length);
         }
+		conn.close();
     }
 
     @Test

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardStatsTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardStatsTest.java
@@ -16,16 +16,17 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HALYARD;
-import com.msd.gin.halyard.sail.HBaseSail;
-import com.msd.gin.halyard.sail.VOID_EXT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.apache.commons.cli.MissingOptionException;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.hadoop.util.ToolRunner;
@@ -47,9 +48,14 @@ import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorLogger;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HALYARD;
+import com.msd.gin.halyard.sail.HBaseSail;
+import com.msd.gin.halyard.sail.VOID_EXT;
 
 /**
  *
@@ -61,18 +67,19 @@ public class HalyardStatsTest {
     public void testStatsTarget() throws Exception {
         final HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "statsTable", true, -1, true, 0, null, null);
         sail.initialize();
-        try (InputStream ref = HalyardStatsTest.class.getResourceAsStream("testData.trig")) {
-            RDFParser p = Rio.createParser(RDFFormat.TRIG);
-            p.setPreserveBNodeIDs(true);
-            p.setRDFHandler(new AbstractRDFHandler() {
-                @Override
-                public void handleStatement(Statement st) throws RDFHandlerException {
-                    sail.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
-                }
-            }).parse(ref, "");
-        }
-        sail.commit();
-        sail.close();
+		try (SailConnection conn = sail.getConnection()) {
+			try (InputStream ref = HalyardStatsTest.class.getResourceAsStream("testData.trig")) {
+				RDFParser p = Rio.createParser(RDFFormat.TRIG);
+				p.setPreserveBNodeIDs(true);
+				p.setRDFHandler(new AbstractRDFHandler() {
+					@Override
+					public void handleStatement(Statement st) throws RDFHandlerException {
+						conn.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
+					}
+				}).parse(ref, "");
+			}
+			conn.commit();
+		}
 
         File root = File.createTempFile("test_stats", "");
         root.delete();
@@ -149,82 +156,82 @@ public class HalyardStatsTest {
         sail.initialize();
 
         //load test data
-        try (InputStream ref = HalyardStatsTest.class.getResourceAsStream("testData.trig")) {
-            RDFParser p = Rio.createParser(RDFFormat.TRIG);
-            p.setPreserveBNodeIDs(true);
-            p.setRDFHandler(new AbstractRDFHandler() {
-                @Override
-                public void handleStatement(Statement st) throws RDFHandlerException {
-                    sail.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
-                }
-            }).parse(ref, "");
-        }
-        sail.commit();
+		try (SailConnection conn = sail.getConnection()) {
+			try (InputStream ref = HalyardStatsTest.class.getResourceAsStream("testData.trig")) {
+				RDFParser p = Rio.createParser(RDFFormat.TRIG);
+				p.setPreserveBNodeIDs(true);
+				p.setRDFHandler(new AbstractRDFHandler() {
+					@Override
+					public void handleStatement(Statement st) throws RDFHandlerException {
+						conn.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
+					}
+				}).parse(ref, "");
+			}
+			conn.commit();
 
-        //update stats
-        assertEquals(0, ToolRunner.run(HBaseServerTestInstance.getInstanceConfig(), new HalyardStats(),
-                new String[]{"-s", "statsTable2", "-r", "100"}));
+			// update stats
+			assertEquals(0, ToolRunner.run(HBaseServerTestInstance.getInstanceConfig(), new HalyardStats(), new String[] { "-s", "statsTable2", "-r", "100" }));
 
-        //verify with golden file
-        Set<Statement> statsM = new HashSet<>();
-        try (CloseableIteration<? extends Statement,SailException> it = sail.getStatements(null, null, null, true, HALYARD.STATS_GRAPH_CONTEXT)) {
-            while (it.hasNext()) {
-                statsM.add(it.next());
-            }
-        }
-        try (InputStream refStream = HalyardStatsTest.class.getResourceAsStream("testStatsTarget.trig")) {
-            Model refM = Rio.parse(refStream, "", RDFFormat.TRIG, new ParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true), SimpleValueFactory.getInstance(), new ParseErrorLogger());
-            assertEqualModels(refM, statsM);
-        }
+			// verify with golden file
+			Set<Statement> statsM = new HashSet<>();
+			try (CloseableIteration<? extends Statement, SailException> it = conn.getStatements(null, null, null, true, HALYARD.STATS_GRAPH_CONTEXT)) {
+				while (it.hasNext()) {
+					statsM.add(it.next());
+				}
+			}
+			try (InputStream refStream = HalyardStatsTest.class.getResourceAsStream("testStatsTarget.trig")) {
+				Model refM = Rio.parse(refStream, "", RDFFormat.TRIG, new ParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true), SimpleValueFactory.getInstance(), new ParseErrorLogger());
+				assertEqualModels(refM, statsM);
+			}
 
-        //load additional data
-        try (InputStream ref = HalyardStatsTest.class.getResourceAsStream("testMoreData.trig")) {
-            RDFParser p = Rio.createParser(RDFFormat.TRIG);
-            p.setPreserveBNodeIDs(true);
-            p.setRDFHandler(new AbstractRDFHandler() {
-                @Override
-                public void handleStatement(Statement st) throws RDFHandlerException {
-                    sail.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
-                }
-            }).parse(ref, "");
-        }
-        sail.commit();
+			// load additional data
+			try (InputStream ref = HalyardStatsTest.class.getResourceAsStream("testMoreData.trig")) {
+				RDFParser p = Rio.createParser(RDFFormat.TRIG);
+				p.setPreserveBNodeIDs(true);
+				p.setRDFHandler(new AbstractRDFHandler() {
+					@Override
+					public void handleStatement(Statement st) throws RDFHandlerException {
+						conn.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
+					}
+				}).parse(ref, "");
+			}
+			conn.commit();
 
-        //update stats only for graph1
-        assertEquals(0, ToolRunner.run(HBaseServerTestInstance.getInstanceConfig(), new HalyardStats(),
-                new String[]{"-s", "statsTable2", "-r", "100", "-c", "http://whatever/graph1"}));
+			// update stats only for graph1
+			assertEquals(0, ToolRunner.run(HBaseServerTestInstance.getInstanceConfig(), new HalyardStats(), new String[] { "-s", "statsTable2", "-r", "100", "-c", "http://whatever/graph1" }));
 
-        //verify with golden file
-        statsM = new HashSet<>();
-        try (CloseableIteration<? extends Statement,SailException> it = sail.getStatements(null, null, null, true, HALYARD.STATS_GRAPH_CONTEXT)) {
-            while (it.hasNext()) {
-                statsM.add(it.next());
-            }
-        }
-        try (InputStream refStream = HalyardStatsTest.class.getResourceAsStream("testStatsMoreTarget.trig")) {
-            Model refM = Rio.parse(refStream, "", RDFFormat.TRIG, new ParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true), SimpleValueFactory.getInstance(), new ParseErrorLogger());
-            assertEqualModels(refM, statsM);
-        }
+			// verify with golden file
+			statsM = new HashSet<>();
+			try (CloseableIteration<? extends Statement, SailException> it = conn.getStatements(null, null, null, true, HALYARD.STATS_GRAPH_CONTEXT)) {
+				while (it.hasNext()) {
+					statsM.add(it.next());
+				}
+			}
+			try (InputStream refStream = HalyardStatsTest.class.getResourceAsStream("testStatsMoreTarget.trig")) {
+				Model refM = Rio.parse(refStream, "", RDFFormat.TRIG, new ParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true), SimpleValueFactory.getInstance(), new ParseErrorLogger());
+				assertEqualModels(refM, statsM);
+			}
 
-        sail.close();
+		}
     }
 
     @Test
     public void testStatsTargetPartial() throws Exception {
         final HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "statsTable3", true, -1, true, 0, null, null);
         sail.initialize();
-        try (InputStream ref = HalyardStatsTest.class.getResourceAsStream("testData.trig")) {
-            RDFParser p = Rio.createParser(RDFFormat.TRIG);
-            p.setPreserveBNodeIDs(true);
-            p.setRDFHandler(new AbstractRDFHandler() {
-                @Override
-                public void handleStatement(Statement st) throws RDFHandlerException {
-                    sail.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
-                }
-            }).parse(ref, "");
-        }
-        sail.commit();
-        sail.close();
+		try (SailConnection conn = sail.getConnection()) {
+			try (InputStream ref = HalyardStatsTest.class.getResourceAsStream("testData.trig")) {
+				RDFParser p = Rio.createParser(RDFFormat.TRIG);
+				p.setPreserveBNodeIDs(true);
+				p.setRDFHandler(new AbstractRDFHandler() {
+					@Override
+					public void handleStatement(Statement st) throws RDFHandlerException {
+						conn.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
+					}
+				}).parse(ref, "");
+			}
+			conn.commit();
+		}
 
         File root = File.createTempFile("test_stats", "");
         root.delete();

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HalyardUpdateTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HalyardUpdateTest.java
@@ -16,13 +16,10 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HBaseSail;
 import java.io.File;
 import java.net.URI;
+
 import org.apache.commons.cli.MissingOptionException;
-import org.junit.Test;
-import org.junit.BeforeClass;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.util.ToolRunner;
@@ -31,11 +28,17 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestName;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
 
 /**
  *
@@ -61,12 +64,14 @@ public class HalyardUpdateTest {
         ValueFactory vf = SimpleValueFactory.getInstance();
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), TABLE, true, 0, true, 0, null, null);
         sail.initialize();
-        for (int i=0; i<5; i++) {
-            for (int j=0; j<5; j++) {
-                sail.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred"), vf.createIRI("http://whatever/obj" + j));
-            }
-        }
-        sail.commit();
+		try (SailConnection conn = sail.getConnection()) {
+			for (int i = 0; i < 5; i++) {
+				for (int j = 0; j < 5; j++) {
+					conn.addStatement(vf.createIRI("http://whatever/subj" + i), vf.createIRI("http://whatever/pred"), vf.createIRI("http://whatever/obj" + j));
+				}
+			}
+			conn.commit();
+		}
         sail.shutDown();
     }
 
@@ -116,14 +121,16 @@ public class HalyardUpdateTest {
         HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), TABLE, false, 0, true, 0, null, null);
         sail.initialize();
         try {
-            CloseableIteration<? extends Statement, SailException> iter = sail.getStatements(null, SimpleValueFactory.getInstance().createIRI("http://whatever/reverse"), null, true);
-            int count = 0;
-            while (iter.hasNext()) {
-                iter.next();
-                count++;
-            }
-            iter.close();
-            Assert.assertEquals(25, count);
+			try (SailConnection conn = sail.getConnection()) {
+				CloseableIteration<? extends Statement, SailException> iter = conn.getStatements(null, SimpleValueFactory.getInstance().createIRI("http://whatever/reverse"), null, true);
+				int count = 0;
+				while (iter.hasNext()) {
+					iter.next();
+					count++;
+				}
+				iter.close();
+				Assert.assertEquals(25, count);
+			}
         } finally {
             sail.shutDown();
         }
@@ -132,9 +139,11 @@ public class HalyardUpdateTest {
         sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), TABLE, false, 0, true, 0, null, null);
         sail.initialize();
         try {
-            CloseableIteration<? extends Statement, SailException> iter = sail.getStatements(null, SimpleValueFactory.getInstance().createIRI("http://whatever/reverse"), null, true);
-            Assert.assertFalse(iter.hasNext());
-            iter.close();
+			try (SailConnection conn = sail.getConnection()) {
+				CloseableIteration<? extends Statement, SailException> iter = conn.getStatements(null, SimpleValueFactory.getInstance().createIRI("http://whatever/reverse"), null, true);
+				Assert.assertFalse(iter.hasNext());
+				iter.close();
+			}
         } finally {
             sail.shutDown();
         }

--- a/tools/src/test/java/com/msd/gin/halyard/tools/HttpSparqlHandlerTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/HttpSparqlHandlerTest.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
@@ -108,14 +109,15 @@ public class HttpSparqlHandlerTest {
         repository.initialize();
 
         // Create repositoryConnection to the sail repository
-        repositoryConnection = repository.getConnection();
-        repositoryConnection.begin();
-
-        // Add some test data
-        repositoryConnection.add(factory.createStatement(SUBJ, PRED, OBJ, CONTEXT));
-        repositoryConnection.add(factory.createStatement(SUBJ2, PRED2, OBJ2, CONTEXT2));
-        repositoryConnection.add(factory.createStatement(SUBJ3, PRED3, OBJ3, CONTEXT3));
-        repositoryConnection.commit();
+        try(RepositoryConnection repositoryConnection = repository.getConnection()) {
+	        repositoryConnection.begin();
+	
+	        // Add some test data
+	        repositoryConnection.add(factory.createStatement(SUBJ, PRED, OBJ, CONTEXT));
+	        repositoryConnection.add(factory.createStatement(SUBJ2, PRED2, OBJ2, CONTEXT2));
+	        repositoryConnection.add(factory.createStatement(SUBJ3, PRED3, OBJ3, CONTEXT3));
+	        repositoryConnection.commit();
+        }
 
         // Provide stored query
         Properties storedQueries = new Properties();
@@ -127,7 +129,7 @@ public class HttpSparqlHandlerTest {
         writerCfg.put("org.eclipse.rdf4j.rio.helpers.JSONLDSettings.JSONLD_MODE", "org.eclipse.rdf4j.rio.helpers.JSONLDMode.COMPACT");
 
         // Create handler with the repositoryConnection to the sail repository
-        HttpSparqlHandler handler = new HttpSparqlHandler(repositoryConnection, storedQueries, writerCfg, true);
+        HttpSparqlHandler handler = new HttpSparqlHandler(repository, storedQueries, writerCfg, true);
 
         // Create and start http server
         server = new SimpleHttpServer(PORT, SERVER_CONTEXT, handler);

--- a/tools/src/test/java/com/msd/gin/halyard/tools/TimeAwareHBaseSailTest.java
+++ b/tools/src/test/java/com/msd/gin/halyard/tools/TimeAwareHBaseSailTest.java
@@ -16,19 +16,18 @@
  */
 package com.msd.gin.halyard.tools;
 
-import com.msd.gin.halyard.common.HBaseServerTestInstance;
-import com.msd.gin.halyard.sail.HBaseSail;
-import org.eclipse.rdf4j.common.iteration.CloseableIteration;
-import org.eclipse.rdf4j.model.Statement;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.eclipse.rdf4j.sail.SailException;
 import org.junit.Test;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+import com.msd.gin.halyard.common.HBaseServerTestInstance;
+import com.msd.gin.halyard.sail.HBaseSail;
 
 /**
  *
@@ -38,8 +37,7 @@ public class TimeAwareHBaseSailTest {
 
     @Test
     public void timestampLongTest() throws Exception {
-        CloseableIteration<? extends Statement, SailException> iter;
-        HBaseSail sail = new TimeAwareHBaseSail(HBaseServerTestInstance.getInstanceConfig(), "timestamptable", true, 0, true, 0, null, null);
+		HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "timestamptable", true, 0, true, 0, null, null, new TimeAwareHBaseSailConnection.Factory());
         SailRepository rep = new SailRepository(sail);
         rep.initialize();
         SailRepositoryConnection con = rep.getConnection();
@@ -54,8 +52,7 @@ public class TimeAwareHBaseSailTest {
 
     @Test
     public void timestampDateTimeTest() throws Exception {
-        CloseableIteration<? extends Statement, SailException> iter;
-        HBaseSail sail = new TimeAwareHBaseSail(HBaseServerTestInstance.getInstanceConfig(), "timestamptable", true, 0, true, 0, null, null);
+		HBaseSail sail = new HBaseSail(HBaseServerTestInstance.getInstanceConfig(), "timestamptable", true, 0, true, 0, null, null, new TimeAwareHBaseSailConnection.Factory());
         SailRepository rep = new SailRepository(sail);
         rep.initialize();
         SailRepositoryConnection con = rep.getConnection();
@@ -69,7 +66,7 @@ public class TimeAwareHBaseSailTest {
 
     private boolean testUpdate(SailRepositoryConnection con, String update) {
         Update u = con.prepareUpdate(update);
-        ((MapBindingSet)u.getBindings()).addBinding(new TimeAwareHBaseSail.TimestampCallbackBinding());
+		((MapBindingSet) u.getBindings()).addBinding(new TimeAwareHBaseSailConnection.TimestampCallbackBinding());
         u.execute();
         con.commit();
         return con.prepareTupleQuery(QueryLanguage.SPARQL, "select * where {<http://whatever> ?p ?o}").evaluate().hasNext();


### PR DESCRIPTION
I've encountered some thread-safety issues when using multiple connections. HTable is not thread-safe but is currently shared between all HBase sail connections. This PR ensures each sail connection has its own HTable. Further, I've update HTable with the newer Table interface and made it possible to re-use/share Connection objects which are quite expensive to create.